### PR TITLE
Add app level exit codes to match genX generated

### DIFF
--- a/examples/avnet_send_message/app_exit_codes.h
+++ b/examples/avnet_send_message/app_exit_codes.h
@@ -1,0 +1,17 @@
+/* Copyright (c) Microsoft Corporation. All rights reserved.
+   Licensed under the MIT License. */
+
+#pragma once
+
+// Include the DevX exit codes
+#include "dx_exit_codes.h"
+
+/// <summary>
+/// Exit codes for this application.  Application exit codes 
+/// must be between 1 and 149, where 0 is reserved for successful 
+//  termination.  Exit codes 150 - 254 are reserved for the
+//  Exit_Code enumeration located in dx_exit_codes.h.
+/// </summary>
+typedef enum {
+	APP_ExitCode_Telemetry_Buffer_Too_Small = 1
+} App_Exit_Code;

--- a/examples/avnet_send_message/main.c
+++ b/examples/avnet_send_message/main.c
@@ -40,7 +40,7 @@
 #include "dx_avnet_iot_connect.h"
 #include "dx_azure_iot.h"
 #include "dx_config.h"
-#include "dx_exit_codes.h"
+#include "app_exit_codes.h"
 #include "dx_json_serializer.h"
 #include "dx_terminate.h"
 #include "dx_timer.h"
@@ -132,6 +132,7 @@ static void publish_message_handler(EventLoopTimer *eventLoopTimer)
 
         } else {
             Log_Debug("JSON Serialization failed: Buffer too small\n");
+            dx_terminate(APP_ExitCode_Telemetry_Buffer_Too_Small);
         }
 
         if (dt_desired_temperature.propertyUpdated) {

--- a/examples/avnet_send_message/main.c
+++ b/examples/avnet_send_message/main.c
@@ -1,51 +1,47 @@
 /* Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  *
- *   DISCLAIMER
+ * This example is built on the Azure Sphere DevX library.
+ *   1. DevX is an Open Source community-maintained implementation of the Azure Sphere SDK samples.
+ *   2. DevX is a modular library that simplifies common development scenarios.
+ *        - You can focus on your solution, not the plumbing.
+ *   3. DevX documentation is maintained at https://github.com/gloveboxes/AzureSphereDevX/wiki
+ *	 4. The DevX library is not a substitute for understanding the Azure Sphere SDK Samples.
+ *          - https://github.com/Azure/azure-sphere-samples
  *
- *   The DevX library supports the Azure Sphere Developer Learning Path:
+ * DEVELOPER BOARD SELECTION
  *
- *	   1. are built from the Azure Sphere SDK Samples at
- *          https://github.com/Azure/azure-sphere-samples
- *	   2. are not intended as a substitute for understanding the Azure Sphere SDK Samples.
- *	   3. aim to follow best practices as demonstrated by the Azure Sphere SDK Samples.
- *	   4. are provided as is and as a convenience to aid the Azure Sphere Developer Learning
- *          experience.
+ * The following developer boards are supported.
  *
- *   DEVELOPER BOARD SELECTION
+ *	 1. AVNET Azure Sphere Starter Kit.
+ *   2. AVNET Azure Sphere Starter Kit Revision 2.
+ *	 3. Seeed Studio Azure Sphere MT3620 Development Kit aka Reference Design Board or rdb.
+ *	 4. Seeed Studio Seeed Studio MT3620 Mini Dev Board.
  *
- *   The following developer boards are supported.
+ * ENABLE YOUR DEVELOPER BOARD
  *
- *	   1. AVNET Azure Sphere Starter Kit.
- *     2. AVNET Azure Sphere Starter Kit Revision 2.
- *	   3. Seeed Studio Azure Sphere MT3620 Development Kit aka Reference Design Board or rdb.
- *	   4. Seeed Studio Seeed Studio MT3620 Mini Dev Board.
+ * Each Azure Sphere developer board manufacturer maps pins differently. You need to select the
+ *    configuration that matches your board.
  *
- *   ENABLE YOUR DEVELOPER BOARD
+ * Follow these steps:
  *
- *   Each Azure Sphere developer board manufacturer maps pins differently. You need to select the
- *      configuration that matches your board.
- *
- *   Follow these steps:
- *
- *	   1. Open CMakeLists.txt.
- *	   2. Uncomment the set command that matches your developer board.
- *	   3. Click File, then Save to save the CMakeLists.txt file which will auto generate the
- *          CMake Cache.
+ *	 1. Open CMakeLists.txt.
+ *	 2. Uncomment the set command that matches your developer board.
+ *	 3. Click File, then Save to auto-generate the CMake Cache.
  *
  ************************************************************************************************/
 
 #include "hw/azure_sphere_learning_path.h" // Hardware definition
 
+#include "app_exit_codes.h"
 #include "dx_avnet_iot_connect.h"
 #include "dx_azure_iot.h"
 #include "dx_config.h"
-#include "app_exit_codes.h"
+#include "dx_device_twins.h"
 #include "dx_json_serializer.h"
 #include "dx_terminate.h"
 #include "dx_timer.h"
 #include "dx_utilities.h"
-#include "dx_device_twins.h"
 #include <applibs/log.h>
 
 // https://docs.microsoft.com/en-us/azure/iot-pnp/overview-iot-plug-and-play

--- a/examples/azure_end_to_end/app_exit_codes.h
+++ b/examples/azure_end_to_end/app_exit_codes.h
@@ -1,0 +1,14 @@
+#pragma once
+
+/* Copyright (c) Microsoft Corporation. All rights reserved.
+   Licensed under the MIT License. */
+
+/// <summary>
+/// Exit codes for this application. Application exit codes
+/// must be between 1 and 149, where 0 is reserved for successful 
+//  termination.  dx_exit_codes.h owns/defines exit codes 0 and 
+/// 150 - 254.
+/// </summary>
+typedef enum {
+	APP_ExitCode_Telemetry_Buffer_Too_Small = 1
+} App_Exit_Code;

--- a/examples/azure_end_to_end/main.c
+++ b/examples/azure_end_to_end/main.c
@@ -39,7 +39,7 @@
 
 #include "dx_azure_iot.h"
 #include "dx_config.h"
-#include "dx_exit_codes.h"
+#include "app_exit_codes.h"
 #include "dx_json_serializer.h"
 #include "dx_terminate.h"
 #include "dx_timer.h"
@@ -131,6 +131,7 @@ static void publish_message_handler(EventLoopTimer *eventLoopTimer)
 
         } else {
             Log_Debug("JSON Serialization failed: Buffer too small\n");
+            dx_terminate(APP_ExitCode_Telemetry_Buffer_Too_Small);
         }
     }
 }

--- a/examples/azure_end_to_end/main.c
+++ b/examples/azure_end_to_end/main.c
@@ -1,45 +1,41 @@
 /* Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  *
- *   DISCLAIMER
+ * This example is built on the Azure Sphere DevX library.
+ *   1. DevX is an Open Source community-maintained implementation of the Azure Sphere SDK samples.
+ *   2. DevX is a modular library that simplifies common development scenarios.
+ *        - You can focus on your solution, not the plumbing.
+ *   3. DevX documentation is maintained at https://github.com/gloveboxes/AzureSphereDevX/wiki
+ *	 4. The DevX library is not a substitute for understanding the Azure Sphere SDK Samples.
+ *          - https://github.com/Azure/azure-sphere-samples
  *
- *   The DevX library supports the Azure Sphere Developer Learning Path:
+ * DEVELOPER BOARD SELECTION
  *
- *	   1. are built from the Azure Sphere SDK Samples at
- *          https://github.com/Azure/azure-sphere-samples
- *	   2. are not intended as a substitute for understanding the Azure Sphere SDK Samples.
- *	   3. aim to follow best practices as demonstrated by the Azure Sphere SDK Samples.
- *	   4. are provided as is and as a convenience to aid the Azure Sphere Developer Learning
- *          experience.
+ * The following developer boards are supported.
  *
- *   DEVELOPER BOARD SELECTION
+ *	 1. AVNET Azure Sphere Starter Kit.
+ *   2. AVNET Azure Sphere Starter Kit Revision 2.
+ *	 3. Seeed Studio Azure Sphere MT3620 Development Kit aka Reference Design Board or rdb.
+ *	 4. Seeed Studio Seeed Studio MT3620 Mini Dev Board.
  *
- *   The following developer boards are supported.
+ * ENABLE YOUR DEVELOPER BOARD
  *
- *	   1. AVNET Azure Sphere Starter Kit.
- *     2. AVNET Azure Sphere Starter Kit Revision 2.
- *	   3. Seeed Studio Azure Sphere MT3620 Development Kit aka Reference Design Board or rdb.
- *	   4. Seeed Studio Seeed Studio MT3620 Mini Dev Board.
+ * Each Azure Sphere developer board manufacturer maps pins differently. You need to select the
+ *    configuration that matches your board.
  *
- *   ENABLE YOUR DEVELOPER BOARD
+ * Follow these steps:
  *
- *   Each Azure Sphere developer board manufacturer maps pins differently. You need to select the
- *      configuration that matches your board.
- *
- *   Follow these steps:
- *
- *	   1. Open CMakeLists.txt.
- *	   2. Uncomment the set command that matches your developer board.
- *	   3. Click File, then Save to save the CMakeLists.txt file which will auto generate the
- *          CMake Cache.
+ *	 1. Open CMakeLists.txt.
+ *	 2. Uncomment the set command that matches your developer board.
+ *	 3. Click File, then Save to auto-generate the CMake Cache.
  *
  ************************************************************************************************/
 
 #include "hw/azure_sphere_learning_path.h" // Hardware definition
 
+#include "app_exit_codes.h"
 #include "dx_azure_iot.h"
 #include "dx_config.h"
-#include "app_exit_codes.h"
 #include "dx_json_serializer.h"
 #include "dx_terminate.h"
 #include "dx_timer.h"

--- a/examples/azure_send_message/app_exit_codes.h
+++ b/examples/azure_send_message/app_exit_codes.h
@@ -1,0 +1,17 @@
+/* Copyright (c) Microsoft Corporation. All rights reserved.
+   Licensed under the MIT License. */
+
+#pragma once
+
+// Include the DevX exit codes
+#include "dx_exit_codes.h"
+
+/// <summary>
+/// Exit codes for this application.  Application exit codes 
+/// must be between 1 and 149, where 0 is reserved for successful 
+//  termination.  Exit codes 150 - 254 are reserved for the
+//  Exit_Code enumeration located in dx_exit_codes.h.
+/// </summary>
+typedef enum {
+	APP_ExitCode_Telemetry_Buffer_Too_Small = 1
+} App_Exit_Code;

--- a/examples/azure_send_message/main.c
+++ b/examples/azure_send_message/main.c
@@ -1,46 +1,42 @@
 /* Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  *
- *   DISCLAIMER
+ * This example is built on the Azure Sphere DevX library.
+ *   1. DevX is an Open Source community-maintained implementation of the Azure Sphere SDK samples.
+ *   2. DevX is a modular library that simplifies common development scenarios.
+ *        - You can focus on your solution, not the plumbing.
+ *   3. DevX documentation is maintained at https://github.com/gloveboxes/AzureSphereDevX/wiki
+ *	 4. The DevX library is not a substitute for understanding the Azure Sphere SDK Samples.
+ *          - https://github.com/Azure/azure-sphere-samples
  *
- *   The DevX library supports the Azure Sphere Developer Learning Path:
+ * DEVELOPER BOARD SELECTION
  *
- *	   1. are built from the Azure Sphere SDK Samples at
- *          https://github.com/Azure/azure-sphere-samples
- *	   2. are not intended as a substitute for understanding the Azure Sphere SDK Samples.
- *	   3. aim to follow best practices as demonstrated by the Azure Sphere SDK Samples.
- *	   4. are provided as is and as a convenience to aid the Azure Sphere Developer Learning
- *          experience.
+ * The following developer boards are supported.
  *
- *   DEVELOPER BOARD SELECTION
+ *	 1. AVNET Azure Sphere Starter Kit.
+ *   2. AVNET Azure Sphere Starter Kit Revision 2.
+ *	 3. Seeed Studio Azure Sphere MT3620 Development Kit aka Reference Design Board or rdb.
+ *	 4. Seeed Studio Seeed Studio MT3620 Mini Dev Board.
  *
- *   The following developer boards are supported.
+ * ENABLE YOUR DEVELOPER BOARD
  *
- *	   1. AVNET Azure Sphere Starter Kit.
- *     2. AVNET Azure Sphere Starter Kit Revision 2.
- *	   3. Seeed Studio Azure Sphere MT3620 Development Kit aka Reference Design Board or rdb.
- *	   4. Seeed Studio Seeed Studio MT3620 Mini Dev Board.
+ * Each Azure Sphere developer board manufacturer maps pins differently. You need to select the
+ *    configuration that matches your board.
  *
- *   ENABLE YOUR DEVELOPER BOARD
+ * Follow these steps:
  *
- *   Each Azure Sphere developer board manufacturer maps pins differently. You need to select the
- *      configuration that matches your board.
- *
- *   Follow these steps:
- *
- *	   1. Open CMakeLists.txt.
- *	   2. Uncomment the set command that matches your developer board.
- *	   3. Click File, then Save to save the CMakeLists.txt file which will auto generate the
- *          CMake Cache.
+ *	 1. Open CMakeLists.txt.
+ *	 2. Uncomment the set command that matches your developer board.
+ *	 3. Click File, then Save to auto-generate the CMake Cache.
  *
  ************************************************************************************************/
 
 #include "hw/azure_sphere_learning_path.h" // Hardware definition
 
+#include "app_exit_codes.h"
 #include "dx_azure_iot.h"
 #include "dx_azure_iot.h"
 #include "dx_config.h"
-#include "app_exit_codes.h"
 #include "dx_json_serializer.h"
 #include "dx_terminate.h"
 #include "dx_timer.h"

--- a/examples/azure_send_message/main.c
+++ b/examples/azure_send_message/main.c
@@ -40,7 +40,7 @@
 #include "dx_azure_iot.h"
 #include "dx_azure_iot.h"
 #include "dx_config.h"
-#include "dx_exit_codes.h"
+#include "app_exit_codes.h"
 #include "dx_json_serializer.h"
 #include "dx_terminate.h"
 #include "dx_timer.h"
@@ -111,6 +111,7 @@ static void publish_message_handler(EventLoopTimer *eventLoopTimer)
 
         } else {
             Log_Debug("JSON Serialization failed: Buffer too small\n");
+            dx_terminate(APP_ExitCode_Telemetry_Buffer_Too_Small);
         }
     }
 }

--- a/examples/deferred_update/app_exit_codes.h
+++ b/examples/deferred_update/app_exit_codes.h
@@ -1,0 +1,17 @@
+/* Copyright (c) Microsoft Corporation. All rights reserved.
+   Licensed under the MIT License. */
+
+#pragma once
+
+// Include the DevX exit codes
+#include "dx_exit_codes.h"
+
+/// <summary>
+/// Exit codes for this application.  Application exit codes 
+/// must be between 1 and 149, where 0 is reserved for successful 
+//  termination.  Exit codes 150 - 254 are reserved for the
+//  Exit_Code enumeration located in dx_exit_codes.h.
+/// </summary>
+typedef enum {
+	APP_ExitCode_Example_Code = 1
+} App_Exit_Code;

--- a/examples/deferred_update/main.c
+++ b/examples/deferred_update/main.c
@@ -37,7 +37,7 @@
 
 #include "hw/azure_sphere_learning_path.h" // Hardware definition
 
-#include "dx_exit_codes.h"
+#include "app_exit_codes.h"
 #include "dx_terminate.h"
 #include "dx_deferred_update.h"
 #include <applibs/log.h>

--- a/examples/deferred_update/main.c
+++ b/examples/deferred_update/main.c
@@ -1,45 +1,41 @@
 /* Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  *
- *   DISCLAIMER
+ * This example is built on the Azure Sphere DevX library.
+ *   1. DevX is an Open Source community-maintained implementation of the Azure Sphere SDK samples.
+ *   2. DevX is a modular library that simplifies common development scenarios.
+ *        - You can focus on your solution, not the plumbing.
+ *   3. DevX documentation is maintained at https://github.com/gloveboxes/AzureSphereDevX/wiki
+ *	 4. The DevX library is not a substitute for understanding the Azure Sphere SDK Samples.
+ *          - https://github.com/Azure/azure-sphere-samples
  *
- *   The DevX library supports the Azure Sphere Developer Learning Path:
+ * DEVELOPER BOARD SELECTION
  *
- *	   1. are built from the Azure Sphere SDK Samples at
- *          https://github.com/Azure/azure-sphere-samples
- *	   2. are not intended as a substitute for understanding the Azure Sphere SDK Samples.
- *	   3. aim to follow best practices as demonstrated by the Azure Sphere SDK Samples.
- *	   4. are provided as is and as a convenience to aid the Azure Sphere Developer Learning
- *          experience.
+ * The following developer boards are supported.
  *
- *   DEVELOPER BOARD SELECTION
+ *	 1. AVNET Azure Sphere Starter Kit.
+ *   2. AVNET Azure Sphere Starter Kit Revision 2.
+ *	 3. Seeed Studio Azure Sphere MT3620 Development Kit aka Reference Design Board or rdb.
+ *	 4. Seeed Studio Seeed Studio MT3620 Mini Dev Board.
  *
- *   The following developer boards are supported.
+ * ENABLE YOUR DEVELOPER BOARD
  *
- *	   1. AVNET Azure Sphere Starter Kit.
- *     2. AVNET Azure Sphere Starter Kit Revision 2.
- *	   3. Seeed Studio Azure Sphere MT3620 Development Kit aka Reference Design Board or rdb.
- *	   4. Seeed Studio Seeed Studio MT3620 Mini Dev Board.
+ * Each Azure Sphere developer board manufacturer maps pins differently. You need to select the
+ *    configuration that matches your board.
  *
- *   ENABLE YOUR DEVELOPER BOARD
+ * Follow these steps:
  *
- *   Each Azure Sphere developer board manufacturer maps pins differently. You need to select the
- *      configuration that matches your board.
- *
- *   Follow these steps:
- *
- *	   1. Open CMakeLists.txt.
- *	   2. Uncomment the set command that matches your developer board.
- *	   3. Click File, then Save to save the CMakeLists.txt file which will auto generate the
- *          CMake Cache.
+ *	 1. Open CMakeLists.txt.
+ *	 2. Uncomment the set command that matches your developer board.
+ *	 3. Click File, then Save to auto-generate the CMake Cache.
  *
  ************************************************************************************************/
 
 #include "hw/azure_sphere_learning_path.h" // Hardware definition
 
 #include "app_exit_codes.h"
-#include "dx_terminate.h"
 #include "dx_deferred_update.h"
+#include "dx_terminate.h"
 #include <applibs/log.h>
 
 /****************************************************************************************

--- a/examples/device_twins/app_exit_codes.h
+++ b/examples/device_twins/app_exit_codes.h
@@ -1,0 +1,17 @@
+/* Copyright (c) Microsoft Corporation. All rights reserved.
+   Licensed under the MIT License. */
+
+#pragma once
+
+// Include the DevX exit codes
+#include "dx_exit_codes.h"
+
+/// <summary>
+/// Exit codes for this application.  Application exit codes 
+/// must be between 1 and 149, where 0 is reserved for successful 
+//  termination.  Exit codes 150 - 254 are reserved for the
+//  Exit_Code enumeration located in dx_exit_codes.h.
+/// </summary>
+typedef enum {
+	APP_ExitCode_Example = 1
+} App_Exit_Code;

--- a/examples/device_twins/main.c
+++ b/examples/device_twins/main.c
@@ -1,50 +1,48 @@
 /* Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  *
- *   DISCLAIMER
+ * This example is built on the Azure Sphere DevX library.
+ *   1. DevX is an Open Source community-maintained implementation of the Azure Sphere SDK samples.
+ *   2. DevX is a modular library that simplifies common development scenarios.
+ *        - You can focus on your solution, not the plumbing.
+ *   3. DevX documentation is maintained at https://github.com/gloveboxes/AzureSphereDevX/wiki
+ *	 4. The DevX library is not a substitute for understanding the Azure Sphere SDK Samples.
+ *          - https://github.com/Azure/azure-sphere-samples
  *
- *   The DevX library supports the Azure Sphere Developer Learning Path:
+ * DEVELOPER BOARD SELECTION
  *
- *	   1. are built from the Azure Sphere SDK Samples at
- *          https://github.com/Azure/azure-sphere-samples
- *	   2. are not intended as a substitute for understanding the Azure Sphere SDK Samples.
- *	   3. aim to follow best practices as demonstrated by the Azure Sphere SDK Samples.
- *	   4. are provided as is and as a convenience to aid the Azure Sphere Developer Learning
- *        experience.
+ * The following developer boards are supported.
  *
- *   DEVELOPER BOARD SELECTION
+ *	 1. AVNET Azure Sphere Starter Kit.
+ *   2. AVNET Azure Sphere Starter Kit Revision 2.
+ *	 3. Seeed Studio Azure Sphere MT3620 Development Kit aka Reference Design Board or rdb.
+ *	 4. Seeed Studio Seeed Studio MT3620 Mini Dev Board.
  *
- *   The following developer boards are supported.
+ * ENABLE YOUR DEVELOPER BOARD
  *
- *	   1. AVNET Azure Sphere Starter Kit.
- *     2. AVNET Azure Sphere Starter Kit Revision 2.
- *	   3. Seeed Studio Azure Sphere MT3620 Development Kit aka Reference Design Board or rdb.
- *	   4. Seeed Studio Seeed Studio MT3620 Mini Dev Board.
+ * Each Azure Sphere developer board manufacturer maps pins differently. You need to select the
+ *    configuration that matches your board.
  *
- *   ENABLE YOUR DEVELOPER BOARD
+ * Follow these steps:
  *
- *   Each Azure Sphere developer board manufacturer maps pins differently. You need to select the
- *      configuration that matches your board.
- *
- *   Follow these steps:
- *
- *	   1. Open CMakeLists.txt.
- *	   2. Uncomment the set command that matches your developer board.
- *	   3. Click File, then Save to save the CMakeLists.txt file which will auto generate the
- *          CMake Cache.
+ *	 1. Open CMakeLists.txt.
+ *	 2. Uncomment the set command that matches your developer board.
+ *	 3. Click File, then Save to auto-generate the CMake Cache.
  *
  ************************************************************************************************/
 
 #include "hw/azure_sphere_learning_path.h" // Hardware definition
 
+#include "app_exit_codes.h"
 #include "dx_azure_iot.h"
 #include "dx_config.h"
 #include "dx_device_twins.h"
-#include "app_exit_codes.h"
 #include "dx_terminate.h"
 #include "dx_timer.h"
 #include "dx_utilities.h"
+
 #include <applibs/log.h>
+#include <time.h>
 
 // https://docs.microsoft.com/en-us/azure/iot-pnp/overview-iot-plug-and-play
 #define IOT_PLUG_AND_PLAY_MODEL_ID "dtmi:com:example:azuresphere:labmonitor;1"
@@ -55,6 +53,9 @@
 #define JSON_MESSAGE_BYTES 256
 static char msgBuffer[JSON_MESSAGE_BYTES] = {0};
 
+#define LOCAL_DEVICE_TWIN_PROPERTY 64
+static char copy_of_property_value[LOCAL_DEVICE_TWIN_PROPERTY];
+
 DX_USER_CONFIG dx_config;
 
 // Forward declarations
@@ -62,14 +63,29 @@ static void report_now_handler(EventLoopTimer *eventLoopTimer);
 static void dt_desired_sample_rate_handler(DX_DEVICE_TWIN_BINDING *deviceTwinBinding);
 static void dt_copy_string_handler(DX_DEVICE_TWIN_BINDING *deviceTwinBinding);
 
+static DX_MESSAGE_PROPERTY *sensorErrorProperties[] = {
+    &(DX_MESSAGE_PROPERTY){.key = "appid", .value = "hvac"},
+    &(DX_MESSAGE_PROPERTY){.key = "type", .value = "SensorError"},
+    &(DX_MESSAGE_PROPERTY){.key = "schema", .value = "1"}};
+
+static DX_MESSAGE_CONTENT_PROPERTIES contentProperties = {.contentEncoding = "utf-8",
+                                                          .contentType = "application/json"};
+
 /****************************************************************************************
- * Timer Bindings
+ * Bindings
  ****************************************************************************************/
 static DX_TIMER_BINDING report_now_timer = {
     .period = {5, 0}, .name = "report_now_timer", .handler = report_now_handler};
 
-// All timers in this set will be initialised in the InitPeripheralsAndHandlers function
-DX_TIMER_BINDING *timerSet[] = {&report_now_timer};
+static DX_GPIO_BINDING network_connected_led = {.pin = NETWORK_CONNECTED_LED,
+                              .name = "network connected led",
+                              .direction = DX_OUTPUT,
+                              .initialState = GPIO_Value_Low,
+                              .invertPin = true};
+
+// All bindings referenced in the bindings sets will be initialised in the InitPeripheralsAndHandlers function
+DX_TIMER_BINDING *timer_binding_set[] = {&report_now_timer};
+DX_GPIO_BINDING *gpio_binding_set[] = {&network_connected_led};
 
 /****************************************************************************************
  * Azure IoT Device Twin Bindings
@@ -79,8 +95,8 @@ static DX_DEVICE_TWIN_BINDING dt_desired_sample_rate = {.propertyName = "Desired
                                                         .handler = dt_desired_sample_rate_handler};
 
 static DX_DEVICE_TWIN_BINDING dt_sample_string = {.propertyName = "SampleString",
-                                                 .twinType = DX_DEVICE_TWIN_STRING,
-                                                 .handler = dt_copy_string_handler};
+                                                  .twinType = DX_DEVICE_TWIN_STRING,
+                                                  .handler = dt_copy_string_handler};
 
 static DX_DEVICE_TWIN_BINDING dt_reported_temperature = {.propertyName = "ReportedTemperature",
                                                          .twinType = DX_DEVICE_TWIN_FLOAT};
@@ -94,34 +110,63 @@ static DX_DEVICE_TWIN_BINDING dt_reported_utc = {.propertyName = "ReportedUTC",
 // All device twins listed in device_twin_bindings will be subscribed to in
 // the InitPeripheralsAndHandlers function
 DX_DEVICE_TWIN_BINDING *device_twin_bindings[] = {&dt_desired_sample_rate, &dt_reported_temperature,
-                                                  &dt_reported_humidity, &dt_reported_utc, &dt_sample_string};
+                                                  &dt_reported_humidity, &dt_reported_utc,
+                                                  &dt_sample_string};
 
-// Implementation
 
+// Validate sensor readings and report device twins
 static void report_now_handler(EventLoopTimer *eventLoopTimer)
 {
-    float temperature = 25.05f;
-    double humidity = 60.25;
-
     if (ConsumeEventLoopTimerEvent(eventLoopTimer) != 0) {
         dx_terminate(DX_ExitCode_ConsumeEventLoopTimeEvent);
         return;
     }
 
-    // Update twin with current UTC (Universal Time Coordinate) in ISO format
-    dx_deviceTwinReportValue(&dt_reported_utc, dx_getCurrentUtc(msgBuffer, sizeof(msgBuffer)));
+    //if (!dx_isAzureConnected()) {
+    //    return;
+    //}
 
-    // The type passed in must match the Divice Twin Type DX_DEVICE_TWIN_FLOAT
-    dx_deviceTwinReportValue(&dt_reported_temperature, &temperature);
+    float temperature = 25.05f;
+    // Add some random value to humidity to trigger data out of range error
+    double humidity = 50.00 + (rand() % 70);
 
-    // The type passed in must match the Divice Twin Type DX_DEVICE_TWIN_DOUBLE
-    dx_deviceTwinReportValue(&dt_reported_humidity, &humidity);
+    // Validate sensor data to check within expected range
+    // Is temperature between -20 and 60, is humidity between 0 and 100
+    if (-20.0f < temperature && 60.0f > temperature && 0.0 <= humidity && 100.0 >= humidity) {
+
+        // Update twin with current UTC (Universal Time Coordinate) in ISO format
+        dx_deviceTwinReportValue(&dt_reported_utc, dx_getCurrentUtc(msgBuffer, sizeof(msgBuffer)));
+
+        // The type passed in must match the Divice Twin Type DX_DEVICE_TWIN_FLOAT
+        dx_deviceTwinReportValue(&dt_reported_temperature, &temperature);
+
+        // The type passed in must match the Divice Twin Type DX_DEVICE_TWIN_DOUBLE
+        dx_deviceTwinReportValue(&dt_reported_humidity, &humidity);
+
+    } else { 
+        // Report data not in range        
+        if (dx_jsonSerialize(msgBuffer, sizeof(msgBuffer), 4, 
+                            DX_JSON_STRING, "Sensor", "Environment", 
+                            DX_JSON_STRING, "ErrorMessage", "Telemetry out of range", 
+                            DX_JSON_FLOAT, "Temperature", temperature,
+                            DX_JSON_DOUBLE, "Humidity", humidity)) {
+
+            Log_Debug("%s\n", msgBuffer);
+
+            // Publish sensor out of range error message.
+            // The message metadata type property is set to SensorError.
+            // Using IoT Hub Message Routing you would route the SensorError messages to a maintainance system.
+            dx_azurePublish(msgBuffer, strlen(msgBuffer), sensorErrorProperties,
+                            NELEMS(sensorErrorProperties), &contentProperties);
+        }
+    }
 }
 
 static void dt_desired_sample_rate_handler(DX_DEVICE_TWIN_BINDING *deviceTwinBinding)
 {
     // validate data is sensible range before applying
-    if (deviceTwinBinding->twinType == DX_DEVICE_TWIN_INT && *(int *)deviceTwinBinding->propertyValue >= 0 &&
+    if (deviceTwinBinding->twinType == DX_DEVICE_TWIN_INT &&
+        *(int *)deviceTwinBinding->propertyValue >= 0 &&
         *(int *)deviceTwinBinding->propertyValue <= 120) {
 
         dx_timerChange(&report_now_timer,
@@ -137,41 +182,55 @@ static void dt_desired_sample_rate_handler(DX_DEVICE_TWIN_BINDING *deviceTwinBin
 
     /*	Casting device twin state examples
 
-            float value = *(float*)deviceTwinBinding->propertyValue;
-            double value = *(double*)deviceTwinBinding->propertyValue;
-            int value = *(int*)deviceTwinBinding->propertyValue;
-            bool value = *(bool*)deviceTwinBinding->propertyValue;
-            char* value = (char*)deviceTwinBinding->propertyValue;
+            float value = *(float*)deviceTwinBinding->property_value;
+            double value = *(double*)deviceTwinBinding->property_value;
+            int value = *(int*)deviceTwinBinding->property_value;
+            bool value = *(bool*)deviceTwinBinding->property_value;
+            char* value = (char*)deviceTwinBinding->property_value;
     */
 }
 
-// Sample device twin handler that demonstrates how to manage string device twin types.  When an 
-// application uses a string device twin, the application must make a local copy of the string on 
-// any device twin update.  
+// check string contain only printable characters
+// ! " # $ % & ' ( ) * + , - . / 0 1 2 3 4 5 6 7 8 9 : ; < = > ? @ A B C D E F G H I J K L M N O P Q
+// R S T U V W X Y Z [ \ ] ^ _ ` a b c d e f g h i j k l m n o p q r s t u v w x y z { | } ~
+bool IsDataValid(char *data)
+{
+    while (isprint(*data)) {
+        data++;
+    }
+    return 0x00 == *data;
+}
+
+// Sample device twin handler that demonstrates how to manage string device twin types.  When an
+// application uses a string device twin, the application must make a local copy of the string on
+// any device twin update. This gives you memory control as strings can be of arbitrary length.
 static void dt_copy_string_handler(DX_DEVICE_TWIN_BINDING *deviceTwinBinding)
 {
-    // Define a string array
-    #define MY_STRING_SIZE 63 + 1
-    char stringCopy[MY_STRING_SIZE];
+    char *property_value = (char *)deviceTwinBinding->propertyValue;
 
-    // validate data is a string
-    if (deviceTwinBinding->twinType == DX_DEVICE_TWIN_STRING) {
+    // Validate data. Is data type string, size less than destination buffer and printable characters
+    if (deviceTwinBinding->twinType == DX_DEVICE_TWIN_STRING &&
+        strlen(property_value) < sizeof(copy_of_property_value) && IsDataValid(property_value)) {
 
-        // Copy the string to the local variable, null terminate it in case the incomming string is larger
-        // than MY_STRING_SIZE.
-        strncpy(stringCopy, deviceTwinBinding->propertyValue, MY_STRING_SIZE);
-        stringCopy[MY_STRING_SIZE] = '\0';
-        
+        strncpy(copy_of_property_value, property_value, sizeof(copy_of_property_value));
+
         // Output the new string to debug
-        Log_Debug("Rx device twin update for twin: %s, new value: %s\n", deviceTwinBinding->propertyName, stringCopy);
+        Log_Debug("Rx device twin update for twin: %s, local value: %s\n",
+                  deviceTwinBinding->propertyName, copy_of_property_value);
 
-        dx_deviceTwinAckDesiredValue(deviceTwinBinding, (char*)deviceTwinBinding->propertyValue,
+        dx_deviceTwinAckDesiredValue(deviceTwinBinding, (char *)deviceTwinBinding->propertyValue,
                                      DX_DEVICE_TWIN_RESPONSE_COMPLETED);
 
     } else {
-        dx_deviceTwinAckDesiredValue(deviceTwinBinding, deviceTwinBinding->propertyValue,
+        Log_Debug("Local copy failed. String too long or invalid data\n");
+        dx_deviceTwinAckDesiredValue(deviceTwinBinding, (char *)deviceTwinBinding->propertyValue,
                                      DX_DEVICE_TWIN_RESPONSE_ERROR);
     }
+}
+
+// Set Network Connected state LED
+static void ConnectionStatus(bool connection_state) {
+    dx_gpioStateSet(&network_connected_led, connection_state);
 }
 
 /// <summary>
@@ -180,8 +239,13 @@ static void dt_copy_string_handler(DX_DEVICE_TWIN_BINDING *deviceTwinBinding)
 static void InitPeripheralsAndHandlers(void)
 {
     dx_azureConnect(&dx_config, NETWORK_INTERFACE, IOT_PLUG_AND_PLAY_MODEL_ID);
-    dx_timerSetStart(timerSet, NELEMS(timerSet));
+    dx_timerSetStart(timer_binding_set, NELEMS(timer_binding_set));
+    dx_gpioSetOpen(gpio_binding_set, NELEMS(gpio_binding_set));
     dx_deviceTwinSubscribe(device_twin_bindings, NELEMS(device_twin_bindings));
+
+    dx_azureRegisterConnectionChangedNotification(ConnectionStatus);
+    // Init the random number generator. Used to synthesis humidity telemetry
+    srand((unsigned int)time(NULL));
 }
 
 /// <summary>
@@ -190,7 +254,8 @@ static void InitPeripheralsAndHandlers(void)
 static void ClosePeripheralsAndHandlers(void)
 {
     dx_deviceTwinUnsubscribe();
-    dx_timerSetStop(timerSet, NELEMS(timerSet));
+    dx_timerSetStop(timer_binding_set, NELEMS(timer_binding_set));
+    dx_gpioSetClose(gpio_binding_set, NELEMS(gpio_binding_set));
     dx_timerEventLoopStop();
 }
 

--- a/examples/device_twins/main.c
+++ b/examples/device_twins/main.c
@@ -10,7 +10,7 @@
  *	   2. are not intended as a substitute for understanding the Azure Sphere SDK Samples.
  *	   3. aim to follow best practices as demonstrated by the Azure Sphere SDK Samples.
  *	   4. are provided as is and as a convenience to aid the Azure Sphere Developer Learning
- *experience.
+ *        experience.
  *
  *   DEVELOPER BOARD SELECTION
  *
@@ -40,7 +40,7 @@
 #include "dx_azure_iot.h"
 #include "dx_config.h"
 #include "dx_device_twins.h"
-#include "dx_exit_codes.h"
+#include "app_exit_codes.h"
 #include "dx_terminate.h"
 #include "dx_timer.h"
 #include "dx_utilities.h"

--- a/examples/direct_methods/app_exit_codes.h
+++ b/examples/direct_methods/app_exit_codes.h
@@ -1,0 +1,17 @@
+/* Copyright (c) Microsoft Corporation. All rights reserved.
+   Licensed under the MIT License. */
+
+#pragma once
+
+// Include the DevX exit codes
+#include "dx_exit_codes.h"
+
+/// <summary>
+/// Exit codes for this application.  Application exit codes 
+/// must be between 1 and 149, where 0 is reserved for successful 
+//  termination.  Exit codes 150 - 254 are reserved for the
+//  Exit_Code enumeration located in dx_exit_codes.h.
+/// </summary>
+typedef enum {
+	APP_ExitCode_Example = 1
+} App_Exit_Code;

--- a/examples/direct_methods/main.c
+++ b/examples/direct_methods/main.c
@@ -40,7 +40,7 @@
 #include "dx_azure_iot.h"
 #include "dx_config.h"
 #include "dx_direct_methods.h"
-#include "dx_exit_codes.h"
+#include "app_exit_codes.h"
 #include "dx_gpio.h"
 #include "dx_terminate.h"
 #include "dx_timer.h"

--- a/examples/direct_methods/main.c
+++ b/examples/direct_methods/main.c
@@ -1,38 +1,34 @@
 /* Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  *
- *   DISCLAIMER
+ * This example is built on the Azure Sphere DevX library.
+ *   1. DevX is an Open Source community-maintained implementation of the Azure Sphere SDK samples.
+ *   2. DevX is a modular library that simplifies common development scenarios.
+ *        - You can focus on your solution, not the plumbing.
+ *   3. DevX documentation is maintained at https://github.com/gloveboxes/AzureSphereDevX/wiki
+ *	 4. The DevX library is not a substitute for understanding the Azure Sphere SDK Samples.
+ *          - https://github.com/Azure/azure-sphere-samples
  *
- *   The DevX library supports the Azure Sphere Developer Learning Path:
+ * DEVELOPER BOARD SELECTION
  *
- *	   1. are built from the Azure Sphere SDK Samples at
- *          https://github.com/Azure/azure-sphere-samples
- *	   2. are not intended as a substitute for understanding the Azure Sphere SDK Samples.
- *	   3. aim to follow best practices as demonstrated by the Azure Sphere SDK Samples.
- *	   4. are provided as is and as a convenience to aid the Azure Sphere Developer Learning
- *          experience.
+ * The following developer boards are supported.
  *
- *   DEVELOPER BOARD SELECTION
+ *	 1. AVNET Azure Sphere Starter Kit.
+ *   2. AVNET Azure Sphere Starter Kit Revision 2.
+ *	 3. Seeed Studio Azure Sphere MT3620 Development Kit aka Reference Design Board or rdb.
+ *	 4. Seeed Studio Seeed Studio MT3620 Mini Dev Board.
  *
- *   The following developer boards are supported.
+ * ENABLE YOUR DEVELOPER BOARD
  *
- *	   1. AVNET Azure Sphere Starter Kit.
- *     2. AVNET Azure Sphere Starter Kit Revision 2.
- *	   3. Seeed Studio Azure Sphere MT3620 Development Kit aka Reference Design Board or rdb.
- *	   4. Seeed Studio Seeed Studio MT3620 Mini Dev Board.
+ * Each Azure Sphere developer board manufacturer maps pins differently. You need to select the
+ *    configuration that matches your board.
  *
- *   ENABLE YOUR DEVELOPER BOARD
+ * Follow these steps:
  *
- *   Each Azure Sphere developer board manufacturer maps pins differently. You need to select the
- *      configuration that matches your board.
+ *	 1. Open CMakeLists.txt.
+ *	 2. Uncomment the set command that matches your developer board.
+ *	 3. Click File, then Save to auto-generate the CMake Cache.
  *
- *   Follow these steps:
- *
- *	   1. Open CMakeLists.txt.
- *	   2. Uncomment the set command that matches your developer board.
- *	   3. Click File, then Save to save the CMakeLists.txt file which will auto generate the
- *          CMake Cache.
- * 
  ************************************************************************************************/
 
 #include "hw/azure_sphere_learning_path.h" // Hardware definition

--- a/examples/gpio_example/app_exit_codes.h
+++ b/examples/gpio_example/app_exit_codes.h
@@ -1,0 +1,17 @@
+/* Copyright (c) Microsoft Corporation. All rights reserved.
+   Licensed under the MIT License. */
+
+#pragma once
+
+// Include the DevX exit codes
+#include "dx_exit_codes.h"
+
+/// <summary>
+/// Exit codes for this application.  Application exit codes 
+/// must be between 1 and 149, where 0 is reserved for successful 
+//  termination.  Exit codes 150 - 254 are reserved for the
+//  Exit_Code enumeration located in dx_exit_codes.h.
+/// </summary>
+typedef enum {
+	APP_ExitCode_Example = 1
+} App_Exit_Code;

--- a/examples/gpio_example/main.c
+++ b/examples/gpio_example/main.c
@@ -1,37 +1,33 @@
 /* Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  *
- *   DISCLAIMER
+ * This example is built on the Azure Sphere DevX library.
+ *   1. DevX is an Open Source community-maintained implementation of the Azure Sphere SDK samples.
+ *   2. DevX is a modular library that simplifies common development scenarios.
+ *        - You can focus on your solution, not the plumbing.
+ *   3. DevX documentation is maintained at https://github.com/gloveboxes/AzureSphereDevX/wiki
+ *	 4. The DevX library is not a substitute for understanding the Azure Sphere SDK Samples.
+ *          - https://github.com/Azure/azure-sphere-samples
  *
- *   The DevX library supports the Azure Sphere Developer Learning Path:
+ * DEVELOPER BOARD SELECTION
  *
- *	   1. are built from the Azure Sphere SDK Samples at
- *          https://github.com/Azure/azure-sphere-samples
- *	   2. are not intended as a substitute for understanding the Azure Sphere SDK Samples.
- *	   3. aim to follow best practices as demonstrated by the Azure Sphere SDK Samples.
- *	   4. are provided as is and as a convenience to aid the Azure Sphere Developer Learning
- *          experience.
+ * The following developer boards are supported.
  *
- *   DEVELOPER BOARD SELECTION
+ *	 1. AVNET Azure Sphere Starter Kit.
+ *   2. AVNET Azure Sphere Starter Kit Revision 2.
+ *	 3. Seeed Studio Azure Sphere MT3620 Development Kit aka Reference Design Board or rdb.
+ *	 4. Seeed Studio Seeed Studio MT3620 Mini Dev Board.
  *
- *   The following developer boards are supported.
+ * ENABLE YOUR DEVELOPER BOARD
  *
- *	   1. AVNET Azure Sphere Starter Kit.
- *     2. AVNET Azure Sphere Starter Kit Revision 2.
- *	   3. Seeed Studio Azure Sphere MT3620 Development Kit aka Reference Design Board or rdb.
- *	   4. Seeed Studio Seeed Studio MT3620 Mini Dev Board.
+ * Each Azure Sphere developer board manufacturer maps pins differently. You need to select the
+ *    configuration that matches your board.
  *
- *   ENABLE YOUR DEVELOPER BOARD
+ * Follow these steps:
  *
- *   Each Azure Sphere developer board manufacturer maps pins differently. You need to select the
- *      configuration that matches your board.
- *
- *   Follow these steps:
- *
- *	   1. Open CMakeLists.txt.
- *	   2. Uncomment the set command that matches your developer board.
- *	   3. Click File, then Save to save the CMakeLists.txt file which will auto generate the
- *          CMake Cache.
+ *	 1. Open CMakeLists.txt.
+ *	 2. Uncomment the set command that matches your developer board.
+ *	 3. Click File, then Save to auto-generate the CMake Cache.
  *
  ************************************************************************************************/
 

--- a/examples/gpio_example/main.c
+++ b/examples/gpio_example/main.c
@@ -37,7 +37,7 @@
 
 #include "hw/azure_sphere_learning_path.h" // Hardware definition
 
-#include "dx_exit_codes.h"
+#include "app_exit_codes.h"
 #include "dx_gpio.h"
 #include "dx_terminate.h"
 #include "dx_timer.h"

--- a/examples/intercore_example/HighLevelApp/app_exit_codes.h
+++ b/examples/intercore_example/HighLevelApp/app_exit_codes.h
@@ -1,0 +1,17 @@
+/* Copyright (c) Microsoft Corporation. All rights reserved.
+   Licensed under the MIT License. */
+
+#pragma once
+
+// Include the DevX exit codes
+#include "dx_exit_codes.h"
+
+/// <summary>
+/// Exit codes for this application.  Application exit codes 
+/// must be between 1 and 149, where 0 is reserved for successful 
+//  termination.  Exit codes 150 - 254 are reserved for the
+//  Exit_Code enumeration located in dx_exit_codes.h.
+/// </summary>
+typedef enum {
+	APP_ExitCode_Example = 1
+} App_Exit_Code;

--- a/examples/intercore_example/HighLevelApp/main.c
+++ b/examples/intercore_example/HighLevelApp/main.c
@@ -14,14 +14,14 @@
  *   ENABLE YOUR DEVELOPER BOARD
  *
  *   Each Azure Sphere developer board manufacturer maps pins differently. You need to select the
- *configuration that matches your board.
+ *   configuration that matches your board.
  *
  *   Follow these steps:
  *
  *	   1. Open CMakeLists.txt.
  *	   2. Uncomment the set command that matches your developer board.
  *	   3. Click File, then Save to save the CMakeLists.txt file which will auto generate the
- *CMake Cache.
+ *        CMake Cache.
  *
  *
  *
@@ -32,19 +32,19 @@
  * Ideal when you have multiple VS Code instances
  *
  * Install the Peacock extension from
- *https://marketplace.visualstudio.com/items?itemName=johnpapa.vscode-peacock
+ * https://marketplace.visualstudio.com/items?itemName=johnpapa.vscode-peacock
  *
  * The following colours have been set:
  * The VS Code instance attached to the Real-Time core will be red. Real-time is red, as in racing
- *red. The VS Code instance attached to the High-level core is blue. High-level is blue, as in sky
- *is high and blue. You can change the default colours to match your preferences.
+ * red. The VS Code instance attached to the High-level core is blue. High-level is blue, as in sky
+ * is high and blue. You can change the default colours to match your preferences.
  *
  *
  * Intercore messaging.
  *
  * There needs to be a shared understanding of the data structure being shared between the real-time
- *and high-level apps This shared understanding is declared in the intercore_contract.h file.  This
- *file can be found in the IntercoreContract directory.
+ * and high-level apps This shared understanding is declared in the intercore_contract.h file.  This
+ * file can be found in the IntercoreContract directory.
  *
  *************************************************************************************************************************************/
 
@@ -53,7 +53,7 @@
 
 // Learning Path Libraries
 #include "dx_config.h"
-#include "dx_exit_codes.h"
+#include "app_exit_codes.h"
 #include "dx_intercore.h"
 #include "dx_terminate.h"
 #include "dx_timer.h"

--- a/examples/intercore_example/HighLevelApp/main.c
+++ b/examples/intercore_example/HighLevelApp/main.c
@@ -1,27 +1,33 @@
-﻿/*************************************************************************************************************************************
- *   Please read the disclaimer and the developer board selection section below
+﻿/* Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
  *
+ * This example is built on the Azure Sphere DevX library.
+ *   1. DevX is an Open Source community-maintained implementation of the Azure Sphere SDK samples.
+ *   2. DevX is a modular library that simplifies common development scenarios.
+ *        - You can focus on your solution, not the plumbing.
+ *   3. DevX documentation is maintained at https://github.com/gloveboxes/AzureSphereDevX/wiki
+ *	 4. The DevX library is not a substitute for understanding the Azure Sphere SDK Samples.
+ *          - https://github.com/Azure/azure-sphere-samples
  *
- *   DEVELOPER BOARD SELECTION
+ * DEVELOPER BOARD SELECTION
  *
- *   The following developer boards are supported.
+ * The following developer boards are supported.
  *
- *	   1. AVNET Azure Sphere Starter Kit.
- *     2. AVNET Azure Sphere Starter Kit Revision 2.
- *	   3. Seeed Studio Azure Sphere MT3620 Development Kit aka Reference Design Board or rdb.
- *	   4. Seeed Studio Seeed Studio MT3620 Mini Dev Board.
+ *	 1. AVNET Azure Sphere Starter Kit.
+ *   2. AVNET Azure Sphere Starter Kit Revision 2.
+ *	 3. Seeed Studio Azure Sphere MT3620 Development Kit aka Reference Design Board or rdb.
+ *	 4. Seeed Studio Seeed Studio MT3620 Mini Dev Board.
  *
- *   ENABLE YOUR DEVELOPER BOARD
+ * ENABLE YOUR DEVELOPER BOARD
  *
- *   Each Azure Sphere developer board manufacturer maps pins differently. You need to select the
- *   configuration that matches your board.
+ * Each Azure Sphere developer board manufacturer maps pins differently. You need to select the
+ *    configuration that matches your board.
  *
- *   Follow these steps:
+ * Follow these steps:
  *
- *	   1. Open CMakeLists.txt.
- *	   2. Uncomment the set command that matches your developer board.
- *	   3. Click File, then Save to save the CMakeLists.txt file which will auto generate the
- *        CMake Cache.
+ *	 1. Open CMakeLists.txt.
+ *	 2. Uncomment the set command that matches your developer board.
+ *	 3. Click File, then Save to auto-generate the CMake Cache.
  *
  *
  *

--- a/examples/intercore_example/RealTimeAppOne/main.c
+++ b/examples/intercore_example/RealTimeAppOne/main.c
@@ -1,3 +1,27 @@
+/* Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ *
+ * This example is built on the Azure Sphere DevX library.
+ *   1. DevX is an Open Source community-maintained implementation of the Azure Sphere SDK samples.
+ *   2. DevX is a modular library that simplifies common development scenarios.
+ *        - You can focus on your solution, not the plumbing.
+ *   3. DevX documentation is maintained at https://github.com/gloveboxes/AzureSphereDevX/wiki
+ *	 4. The DevX library is not a substitute for understanding the Azure Sphere SDK Samples.
+ *          - https://github.com/Azure/azure-sphere-samples
+ *
+ * DEVELOPER BOARD SELECTION
+ *
+ * The following developer boards are supported.
+ *
+ *	 1. AVNET Azure Sphere Starter Kit.
+ *   2. AVNET Azure Sphere Starter Kit Revision 2.
+ *	 3. Seeed Studio Azure Sphere MT3620 Development Kit aka Reference Design Board or rdb.
+ *	 4. Seeed Studio Seeed Studio MT3620 Mini Dev Board.
+ *
+ *
+ ************************************************************************************************/
+
+
 #include "intercore.h"
 #include "intercore_contract.h"
 

--- a/examples/intercore_example/RealTimeAppTwo/main.c
+++ b/examples/intercore_example/RealTimeAppTwo/main.c
@@ -1,3 +1,26 @@
+/* Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ *
+ * This example is built on the Azure Sphere DevX library.
+ *   1. DevX is an Open Source community-maintained implementation of the Azure Sphere SDK samples.
+ *   2. DevX is a modular library that simplifies common development scenarios.
+ *        - You can focus on your solution, not the plumbing.
+ *   3. DevX documentation is maintained at https://github.com/gloveboxes/AzureSphereDevX/wiki
+ *	 4. The DevX library is not a substitute for understanding the Azure Sphere SDK Samples.
+ *          - https://github.com/Azure/azure-sphere-samples
+ *
+ * DEVELOPER BOARD SELECTION
+ *
+ * The following developer boards are supported.
+ *
+ *	 1. AVNET Azure Sphere Starter Kit.
+ *   2. AVNET Azure Sphere Starter Kit Revision 2.
+ *	 3. Seeed Studio Azure Sphere MT3620 Development Kit aka Reference Design Board or rdb.
+ *	 4. Seeed Studio Seeed Studio MT3620 Mini Dev Board.
+ *
+ *
+ ************************************************************************************************/
+
 #include "intercore.h"
 #include "intercore_contract.h"
 

--- a/examples/timer_example/app_exit_codes.h
+++ b/examples/timer_example/app_exit_codes.h
@@ -1,0 +1,17 @@
+/* Copyright (c) Microsoft Corporation. All rights reserved.
+   Licensed under the MIT License. */
+
+#pragma once
+
+// Include the DevX exit codes
+#include "dx_exit_codes.h"
+
+/// <summary>
+/// Exit codes for this application.  Application exit codes 
+/// must be between 1 and 149, where 0 is reserved for successful 
+//  termination.  Exit codes 150 - 254 are reserved for the
+//  Exit_Code enumeration located in dx_exit_codes.h.
+/// </summary>
+typedef enum {
+	APP_ExitCode_Example = 1
+} App_Exit_Code;

--- a/examples/timer_example/main.c
+++ b/examples/timer_example/main.c
@@ -37,7 +37,7 @@
 
 #include "hw/azure_sphere_learning_path.h" // Hardware definition
 
-#include "dx_exit_codes.h"
+#include "app_exit_codes.h"
 #include "dx_terminate.h"
 #include "dx_timer.h"
 #include "dx_utilities.h"

--- a/examples/timer_example/main.c
+++ b/examples/timer_example/main.c
@@ -1,37 +1,33 @@
 /* Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  *
- *   DISCLAIMER
+ * This example is built on the Azure Sphere DevX library.
+ *   1. DevX is an Open Source community-maintained implementation of the Azure Sphere SDK samples.
+ *   2. DevX is a modular library that simplifies common development scenarios.
+ *        - You can focus on your solution, not the plumbing.
+ *   3. DevX documentation is maintained at https://github.com/gloveboxes/AzureSphereDevX/wiki
+ *	 4. The DevX library is not a substitute for understanding the Azure Sphere SDK Samples.
+ *          - https://github.com/Azure/azure-sphere-samples
  *
- *   The DevX library supports the Azure Sphere Developer Learning Path:
+ * DEVELOPER BOARD SELECTION
  *
- *	   1. are built from the Azure Sphere SDK Samples at
- *          https://github.com/Azure/azure-sphere-samples
- *	   2. are not intended as a substitute for understanding the Azure Sphere SDK Samples.
- *	   3. aim to follow best practices as demonstrated by the Azure Sphere SDK Samples.
- *	   4. are provided as is and as a convenience to aid the Azure Sphere Developer Learning
- *          experience.
+ * The following developer boards are supported.
  *
- *   DEVELOPER BOARD SELECTION
+ *	 1. AVNET Azure Sphere Starter Kit.
+ *   2. AVNET Azure Sphere Starter Kit Revision 2.
+ *	 3. Seeed Studio Azure Sphere MT3620 Development Kit aka Reference Design Board or rdb.
+ *	 4. Seeed Studio Seeed Studio MT3620 Mini Dev Board.
  *
- *   The following developer boards are supported.
+ * ENABLE YOUR DEVELOPER BOARD
  *
- *	   1. AVNET Azure Sphere Starter Kit.
- *     2. AVNET Azure Sphere Starter Kit Revision 2.
- *	   3. Seeed Studio Azure Sphere MT3620 Development Kit aka Reference Design Board or rdb.
- *	   4. Seeed Studio Seeed Studio MT3620 Mini Dev Board.
+ * Each Azure Sphere developer board manufacturer maps pins differently. You need to select the
+ *    configuration that matches your board.
  *
- *   ENABLE YOUR DEVELOPER BOARD
+ * Follow these steps:
  *
- *   Each Azure Sphere developer board manufacturer maps pins differently. You need to select the
- *      configuration that matches your board.
- *
- *   Follow these steps:
- *
- *	   1. Open CMakeLists.txt.
- *	   2. Uncomment the set command that matches your developer board.
- *	   3. Click File, then Save to save the CMakeLists.txt file which will auto generate the
- *          CMake Cache.
+ *	 1. Open CMakeLists.txt.
+ *	 2. Uncomment the set command that matches your developer board.
+ *	 3. Click File, then Save to auto-generate the CMake Cache.
  *
  ************************************************************************************************/
 

--- a/examples/uart_example/app_exit_codes.h
+++ b/examples/uart_example/app_exit_codes.h
@@ -1,0 +1,17 @@
+/* Copyright (c) Microsoft Corporation. All rights reserved.
+   Licensed under the MIT License. */
+
+#pragma once
+
+// Include the DevX exit codes
+#include "dx_exit_codes.h"
+
+/// <summary>
+/// Exit codes for this application.  Application exit codes 
+/// must be between 1 and 149, where 0 is reserved for successful 
+//  termination.  Exit codes 150 - 254 are reserved for the
+//  Exit_Code enumeration located in dx_exit_codes.h.
+/// </summary>
+typedef enum {
+	APP_ExitCode_Example = 1
+} App_Exit_Code;

--- a/examples/uart_example/main.c
+++ b/examples/uart_example/main.c
@@ -1,37 +1,33 @@
 /* Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  *
- *   DISCLAIMER
+ * This example is built on the Azure Sphere DevX library.
+ *   1. DevX is an Open Source community-maintained implementation of the Azure Sphere SDK samples.
+ *   2. DevX is a modular library that simplifies common development scenarios.
+ *        - You can focus on your solution, not the plumbing.
+ *   3. DevX documentation is maintained at https://github.com/gloveboxes/AzureSphereDevX/wiki
+ *	 4. The DevX library is not a substitute for understanding the Azure Sphere SDK Samples.
+ *          - https://github.com/Azure/azure-sphere-samples
  *
- *   The DevX library supports the Azure Sphere Developer Learning Path:
+ * DEVELOPER BOARD SELECTION
  *
- *	   1. are built from the Azure Sphere SDK Samples at
- *          https://github.com/Azure/azure-sphere-samples
- *	   2. are not intended as a substitute for understanding the Azure Sphere SDK Samples.
- *	   3. aim to follow best practices as demonstrated by the Azure Sphere SDK Samples.
- *	   4. are provided as is and as a convenience to aid the Azure Sphere Developer Learning
- *          experience.
+ * The following developer boards are supported.
  *
- *   DEVELOPER BOARD SELECTION
+ *	 1. AVNET Azure Sphere Starter Kit.
+ *   2. AVNET Azure Sphere Starter Kit Revision 2.
+ *	 3. Seeed Studio Azure Sphere MT3620 Development Kit aka Reference Design Board or rdb.
+ *	 4. Seeed Studio Seeed Studio MT3620 Mini Dev Board.
  *
- *   The following developer boards are supported.
+ * ENABLE YOUR DEVELOPER BOARD
  *
- *	   1. AVNET Azure Sphere Starter Kit.
- *     2. AVNET Azure Sphere Starter Kit Revision 2.
- *	   3. Seeed Studio Azure Sphere MT3620 Development Kit aka Reference Design Board or rdb.
- *	   4. Seeed Studio Seeed Studio MT3620 Mini Dev Board.
+ * Each Azure Sphere developer board manufacturer maps pins differently. You need to select the
+ *    configuration that matches your board.
  *
- *   ENABLE YOUR DEVELOPER BOARD
+ * Follow these steps:
  *
- *   Each Azure Sphere developer board manufacturer maps pins differently. You need to select the
- *      configuration that matches your board.
- *
- *   Follow these steps:
- *
- *	   1. Open CMakeLists.txt.
- *	   2. Uncomment the set command that matches your developer board.
- *	   3. Click File, then Save to save the CMakeLists.txt file which will auto generate the
- *          CMake Cache.
+ *	 1. Open CMakeLists.txt.
+ *	 2. Uncomment the set command that matches your developer board.
+ *	 3. Click File, then Save to auto-generate the CMake Cache.
  *
  ************************************************************************************************/
 

--- a/examples/uart_example/main.c
+++ b/examples/uart_example/main.c
@@ -37,7 +37,7 @@
 
 #include "hw/azure_sphere_learning_path.h" // Hardware definition
 
-#include "dx_exit_codes.h"
+#include "app_exit_codes.h"
 #include "dx_uart.h"
 #include "dx_gpio.h"
 #include "dx_terminate.h"

--- a/include/dx_exit_codes.h
+++ b/include/dx_exit_codes.h
@@ -4,9 +4,10 @@
 #pragma once
 
 /// <summary>
-/// Exit codes for this application. These are used for the
-/// application exit code.  They must all be between zero and 255,
-/// where zero is reserved for successful termination.
+/// Exit codes for the DevX library. These are used for the
+/// library exit codes.  They must all be between 150 and 255,
+/// where zero is reserved for successful termination.  Exit
+/// codes 1 - 149 are reserved for application level exit codes.
 /// </summary>
 typedef enum {
 	DX_ExitCode_Success = 0,


### PR DESCRIPTION
Dave,

After we added application level exit codes to the generator and genX generated applications, I wanted to have the same infrastructure in the DevX examples for consistency.  For the three connected examples I added an exit code condition (APP_ExitCode_Telemetry_Buffer_Too_Small) if the telemetry send buffer was too small.  But for the remaining examples, I could not find a place to put an application specific exit code.  In these examples I just added the app_exit_codes.h with an example entry (APP_ExitCode_Example) in the enumeration.  



