### PR TITLE
Add context pointer and example usage

### DIFF
--- a/examples/device_twins/app_manifest.json
+++ b/examples/device_twins/app_manifest.json
@@ -5,7 +5,13 @@
   "EntryPoint": "/bin/app",
   "CmdArgs": ["--ScopeID", "REPLACE_WITH_YOUR_ID_SCOPE"],
   "Capabilities": {
-    "AllowedConnections": [ 
+    "Gpio": [
+      "$LED_RED",
+      "$LED_GREEN",
+      "$LED_BLUE",
+      "$NETWORK_CONNECTED_LED"
+    ],
+    "AllowedConnections": [
       "global.azure-devices-provisioning.net",
       "REPLACE_WITH_YOUR_IOT_HUB_ENDPOINT_URL"
     ],

--- a/include/dx_device_twins.h
+++ b/include/dx_device_twins.h
@@ -24,6 +24,7 @@ typedef struct _deviceTwinBinding {
 	bool propertyUpdated;
 	DX_DEVICE_TWIN_TYPE twinType;
 	void (*handler)(struct _deviceTwinBinding* deviceTwinBinding);
+	void *context;
 } DX_DEVICE_TWIN_BINDING;
 
 typedef enum


### PR DESCRIPTION
I'm porting my avnet starter kit example to use the DevX libraries and I had a need to generalize some gpio processing from the device twins.  I've added a void* to the device twin binding and added code to the device twin example that shows one way to leverage this new addition.

With this change I can have multiple device twins that drive GPIO pins use a common handler.  I've tested the example code from the cloud and everything works as expected.

