### PR TITLE
Update dx_device_twins.c

### DIFF
--- a/src/dx_device_twins.c
+++ b/src/dx_device_twins.c
@@ -394,7 +394,7 @@ static bool deviceTwinUpdateReportedState(char *reportedPropertiesString)
         return true;
     }
 
-    IoTHubDeviceClient_LL_DoWork(dx_azureClientHandleGet());
+    // IoTHubDeviceClient_LL_DoWork(dx_azureClientHandleGet());
 }
 
 /// <summary>


### PR DESCRIPTION
@bawilless A device twin update had a IoTHubDeviceClient_LL_DoWork at the end that was turning what should be an async call into an sync call. Have removed the call to dowork so a twin update wont force a a sync dowork operation. I believe this is inline with how a twin should operate. The twin update will be picked up by the main IoTHubDeviceClient_LL_DoWork on the 100ms timer in the azure_iot client