### PR TITLE
Add starter project and feature example

### DIFF
--- a/examples/monitor_memory_usage/.vscode/launch.json
+++ b/examples/monitor_memory_usage/.vscode/launch.json
@@ -1,0 +1,27 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch for Azure Sphere High-Level Applications (gdb)",
+            "type": "azurespheredbg",
+            "request": "launch",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": true,
+            "partnerComponents": [],
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ]
+        }
+    ]
+}

--- a/examples/monitor_memory_usage/.vscode/settings.json
+++ b/examples/monitor_memory_usage/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+    "cmake.generator": "Ninja",
+    "cmake.buildDirectory": "${workspaceRoot}/out/ARM-${buildType}",
+    "cmake.buildToolArgs": [ "-v" ],
+    "cmake.configureSettings": {
+        "CMAKE_TOOLCHAIN_FILE": "${command:azuresphere.AzureSphereSdkDir}/CMakeFiles/AzureSphereToolchain.cmake",
+        "AZURE_SPHERE_TARGET_API_SET": "10"
+    },
+    "cmake.configureOnOpen": true,
+    "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools",
+    "files.associations": {
+        "dx_avnet_iot_connect.h": "c",
+        "dx_json_serializer.h": "c"
+    }
+}

--- a/examples/monitor_memory_usage/CMakeLists.txt
+++ b/examples/monitor_memory_usage/CMakeLists.txt
@@ -1,0 +1,55 @@
+#  Copyright (c) Microsoft Corporation. All rights reserved.
+#  Licensed under the MIT License.
+
+###################################################################################################################
+
+# Select your developer board by removing the # tag from the beginning of the line
+
+# The default board selected is the AVNET Azure Sphere Starter Kit Revision 1.
+
+# If you are NOT using the AVNET Revision 1 board be sure to comment out the AVNET board
+
+set(AVNET TRUE "AVNET Azure Sphere Starter Kit Revision 1 ")    
+# set(AVNET_REV_2 TRUE "AVNET Azure Sphere Starter Kit Revision 2 ")             
+# set(SEEED_STUDIO_RDB TRUE "Seeed Studio Azure Sphere MT3620 Development Kit (aka Reference Design Board or rdb)")
+# set(SEEED_STUDIO_MINI TRUE "Seeed Studio Azure Sphere MT3620 Mini Dev Board")
+
+###################################################################################################################
+
+cmake_minimum_required (VERSION 3.10)
+
+project (azure_end_to_end C)
+
+azsphere_configure_tools(TOOLS_REVISION "21.07")
+azsphere_configure_api(TARGET_API_SET "10")
+
+add_subdirectory("../../" out)
+
+# Create executable
+add_executable (${PROJECT_NAME} main.c)
+target_link_libraries (${PROJECT_NAME} applibs pthread gcc_s c azure_sphere_devx)
+target_include_directories(${PROJECT_NAME} PUBLIC ../../include )
+
+
+if(AVNET)
+    add_definitions( -DOEM_AVNET=TRUE )
+    azsphere_target_hardware_definition(${PROJECT_NAME} TARGET_DIRECTORY "../HardwareDefinitions/avnet_mt3620_sk" TARGET_DEFINITION "azure_sphere_learning_path.json")
+endif(AVNET)
+
+if(AVNET_REV_2)
+    add_definitions( -DOEM_AVNET=TRUE )
+    azsphere_target_hardware_definition(${PROJECT_NAME} TARGET_DIRECTORY "../HardwareDefinitions/avnet_mt3620_sk_rev2" TARGET_DEFINITION "azure_sphere_learning_path.json")
+endif(AVNET_REV_2)
+
+if (SEEED_STUDIO_RDB)
+    add_definitions( -DOEM_SEEED_STUDIO=TRUE )
+    azsphere_target_hardware_definition(${PROJECT_NAME} TARGET_DIRECTORY "../HardwareDefinitions/mt3620_rdb" TARGET_DEFINITION "azure_sphere_learning_path.json")
+endif()
+
+if (SEEED_STUDIO_MINI)
+    add_definitions( -DOEM_SEEED_STUDIO_MINI=TRUE )
+    azsphere_target_hardware_definition(${PROJECT_NAME} TARGET_DIRECTORY "../HardwareDefinitions/seeed_mt3620_mdb" TARGET_DEFINITION "azure_sphere_learning_path.json")
+endif(SEEED_STUDIO_MINI)
+
+
+azsphere_target_add_image_package(${PROJECT_NAME})

--- a/examples/monitor_memory_usage/CMakeSettings.json
+++ b/examples/monitor_memory_usage/CMakeSettings.json
@@ -1,0 +1,47 @@
+﻿{
+  "environments": [
+    {
+      "environment": "AzureSphere"
+    }
+  ],
+  "configurations": [
+    {
+      "name": "ARM-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "inheritEnvironments": [
+        "AzureSphere"
+      ],
+      "buildRoot": "${projectDir}\\out\\${name}",
+      "installRoot": "${projectDir}\\out\\${name}",
+      "cmakeToolchain": "${env.AzureSphereDefaultSDKDir}CMakeFiles\\AzureSphereToolchain.cmake",
+      "buildCommandArgs": "-v",
+      "ctestCommandArgs": "",
+      "variables": [
+        {
+          "name": "AZURE_SPHERE_TARGET_API_SET",
+          "value": "10"
+        }
+      ]
+    },
+    {
+      "name": "ARM-Release",
+      "generator": "Ninja",
+      "configurationType": "Release",
+      "inheritEnvironments": [
+        "AzureSphere"
+      ],
+      "buildRoot": "${projectDir}\\out\\${name}",
+      "installRoot": "${projectDir}\\out\\${name}",
+      "cmakeToolchain": "${env.AzureSphereDefaultSDKDir}CMakeFiles\\AzureSphereToolchain.cmake",
+      "buildCommandArgs": "-v",
+      "ctestCommandArgs": "",
+      "variables": [
+        {
+          "name": "AZURE_SPHERE_TARGET_API_SET",
+          "value": "10"
+        }
+      ]
+    }
+  ]
+}

--- a/examples/monitor_memory_usage/README.md
+++ b/examples/monitor_memory_usage/README.md
@@ -1,0 +1,17 @@
+# Azure IoT Starter Project (empty)
+
+This is an empty (starter) project that can be used for new Azure Sphere applications based on the DevX library.  The project connects to an Azure IoTHub,
+IoTCentral, or Avnet's IoTConnect and nothing more.  Use the other examples in this folder to help you see how to build out the project to meet your requirements.  Search the project for "TODO" to see where to add definitions, declarations and code.
+## Config app_manifest.json sample
+
+1. Set ID Scope
+1. Set Allowed connections
+1. Set DeviceAuthentication
+
+For more information refer to:
+
+1. [Adding the Azure Sphere DevX library](https://github.com/gloveboxes/AzureSphereDevX/wiki/Adding-the-DevX-Library)
+1. [Azure Messaging](https://github.com/gloveboxes/AzureSphereDevX/wiki/IoT-Hub-Sending-messages)
+1. [Device Twins](https://github.com/gloveboxes/AzureSphereDevX/wiki/IoT-Hub-Device-Twins)
+1. [Direct Methods](https://github.com/gloveboxes/AzureSphereDevX/wiki/IoT-Hub-Direct-Methods)
+1. [GPIO](https://github.com/gloveboxes/AzureSphereDevX/wiki/Working-with-GPIO)

--- a/examples/monitor_memory_usage/app_exit_codes.h
+++ b/examples/monitor_memory_usage/app_exit_codes.h
@@ -1,0 +1,15 @@
+#pragma once
+
+/* Copyright (c) Microsoft Corporation. All rights reserved.
+   Licensed under the MIT License. */
+
+/// <summary>
+/// Exit codes for this application. Application exit codes
+/// must be between 1 and 149, where 0 is reserved for successful 
+//  termination.  dx_exit_codes.h owns/defines exit codes 0 and 
+/// 150 - 254.
+/// </summary>
+typedef enum {
+	APP_ExitCode_Telemetry_Buffer_Too_Small = 1,
+   DX_ExitCode_ConsumeEventLoopMemoryMonitor = 2
+} App_Exit_Code;

--- a/examples/monitor_memory_usage/app_manifest.json
+++ b/examples/monitor_memory_usage/app_manifest.json
@@ -1,0 +1,16 @@
+{
+  "SchemaVersion": 1,
+  "Name": "TODO_Add_app_name_here",
+  "ComponentId": "b217fd65-ac8d-4d7c-b62c-0d07b5df6357",
+  "EntryPoint": "/bin/app",
+  "CmdArgs": [ "--ScopeID", "TODO_REPLACE_WITH_YOUR_ID_SCOPE" ],
+  "Capabilities": {
+    "Gpio": [],
+    "AllowedConnections": [
+      "global.azure-devices-provisioning.net",
+      "TODO_REPLACE_WITH_YOUR_IOT_HUB_ENDPOINT_URL"
+    ],
+    "DeviceAuthentication": "TODO_REPLACE_WITH_YOUR_AZURE_SPHERE_TENANT_ID"
+  },
+  "ApplicationType": "Default"
+}

--- a/examples/monitor_memory_usage/applibs_versions.h
+++ b/examples/monitor_memory_usage/applibs_versions.h
@@ -1,0 +1,25 @@
+#pragma once
+
+/// <summary>
+/// This identifier should be defined before including any of the networking-related header files.
+/// It indicates which version of the Wi-Fi data structures the application uses.
+/// </summary>
+#define NETWORKING_STRUCTS_VERSION 1
+
+/// <summary>
+/// This identifier must be defined before including any of the Wi-Fi related header files.
+/// It indicates which version of the Wi-Fi data structures the application uses.
+/// </summary>
+#define WIFICONFIG_STRUCTS_VERSION 1
+
+/// <summary>
+/// This identifier must be defined before including any of the UART-related header files.
+/// It indicates which version of the UART data structures the application uses.
+/// </summary>
+#define UART_STRUCTS_VERSION 1
+
+/// <summary>
+/// This identifier must be defined before including any of the SPI-related header files.
+/// It indicates which version of the SPI data structures the application uses.
+/// </summary>
+#define SPI_STRUCTS_VERSION 1

--- a/examples/monitor_memory_usage/launch.vs.json
+++ b/examples/monitor_memory_usage/launch.vs.json
@@ -1,0 +1,21 @@
+﻿{
+  "version": "0.2.1",
+  "defaults": {},
+  "configurations": [
+    {
+      "type": "azurespheredbg",
+      "name": "GDB Debugger (HLCore)",
+      "project": "CMakeLists.txt",
+      "inheritEnvironments": [
+        "AzureSphere"
+      ],
+      "customLauncher": "AzureSphereLaunchOptions",
+      "workingDirectory": "${workspaceRoot}",
+      "applicationPath": "${debugInfo.target}",
+      "imagePath": "${debugInfo.targetImage}",
+      "targetCore": "HLCore",
+      "targetApiSet": "${env.AzureSphereTargetApiSet}",
+      "partnerComponents": [ "6583cf17-d321-4d72-8283-0b7c5b56442b" ]
+    }
+  ]
+}

--- a/examples/monitor_memory_usage/main.c
+++ b/examples/monitor_memory_usage/main.c
@@ -1,0 +1,185 @@
+/* Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ *
+ * This example is built on the Azure Sphere DevX library.
+ *   1. DevX is an Open Source community-maintained implementation of the Azure Sphere SDK samples.
+ *   2. DevX is a modular library that simplifies common development scenarios.
+ *        - You can focus on your solution, not the plumbing.
+ *   3. DevX documentation is maintained at https://github.com/gloveboxes/AzureSphereDevX/wiki
+ *	 4. The DevX library is not a substitute for understanding the Azure Sphere SDK Samples.
+ *          - https://github.com/Azure/azure-sphere-samples
+ *
+ * DEVELOPER BOARD SELECTION
+ *
+ * The following developer boards are supported.
+ *
+ *	 1. AVNET Azure Sphere Starter Kit.
+ *   2. AVNET Azure Sphere Starter Kit Revision 2.
+ *	 3. Seeed Studio Azure Sphere MT3620 Development Kit aka Reference Design Board or rdb.
+ *	 4. Seeed Studio Seeed Studio MT3620 Mini Dev Board.
+ *
+ * ENABLE YOUR DEVELOPER BOARD
+ *
+ * Each Azure Sphere developer board manufacturer maps pins differently. You need to select the
+ *    configuration that matches your board.
+ *
+ * Follow these steps:
+ *
+ *	 1. Open CMakeLists.txt.
+ *	 2. Uncomment the set command that matches your developer board.
+ *	 3. Click File, then Save to auto-generate the CMake Cache.
+ *
+ *  Application Notes
+ *   This example application monitors the application's memory usage (every 30 seconde).  
+ *   If the memory usage grows a telemetry message is sent with the new memory value.  
+ *   There is also a direct method "MemoryLeak": {"LeakSize": <integer in KB> } that can 
+ *   be used to exercise the feature.  
+ * 
+ *   Developers should read the Microsoft documentation on memory usage
+ *   https://docs.microsoft.com/en-us/azure-sphere/app-development/application-memory-usage?tabs=windows&pivots=cli
+ * 
+ ************************************************************************************************/
+
+#include "main.h"
+
+/****************************************************************************************
+ * Implementation
+ ****************************************************************************************/
+
+// Direct method name = MemoryLeak, json payload = {"LeakSize": <integer in KB> }
+static DX_DIRECT_METHOD_RESPONSE_CODE MemoryLeakHandler(JSON_Value *json, DX_DIRECT_METHOD_BINDING *directMethodBinding, char **responseMsg)
+{
+    char state_str[] = "LeakSize";
+    int memoryToLeak = 0; 
+
+    JSON_Object *jsonObject = json_value_get_object(json);
+    if (jsonObject == NULL) {
+        return DX_METHOD_FAILED;
+    }
+
+    // Pull and validate the payload from the direct method call
+    memoryToLeak = (int)json_object_get_number(jsonObject, state_str);
+    if(!IN_RANGE(memoryToLeak, MIN_MEMORY_LEAK, MAX_MEMORY_LEAK)){
+        return DX_METHOD_FAILED;
+    }
+    
+    Log_Debug("Leaking %dKB of memory!\n", memoryToLeak);
+    
+    // Allocate memory, but don't release it!
+    if(malloc((size_t)(memoryToLeak * 1024)) != NULL){
+        return DX_METHOD_SUCCEEDED;
+    }
+    
+    Log_Debug("Malloc() failed!\n");
+    return DX_METHOD_FAILED;
+}
+
+// Handler
+/*
+* Note from the Azure Sphere Documentation on memory usage:
+* https://docs.microsoft.com/en-us/azure-sphere/app-development/application-memory-usage?tabs=windows&pivots=cli#determine-run-time-application-ram-usage
+* These functions return the memory usage as seen by the OS. Currently, the 
+* freeing of memory by an application for allocations on the user heap is not 
+* reported by these functions. The memory will be returned to the malloc library
+* for future use but the statistics reported by the OS remain unchanged unless 
+* the memory was allocated and freed by the OS itself. An example would be 
+* allocating memory for a socket. Therefore, these functions are useful for 
+* understanding worst-case scenarios to help your application operate 
+* conservatively for maximum reliability. Values are approximate and may vary 
+* across OS versions.
+*/
+static void monitor_memory_handler(EventLoopTimer *eventLoopTimer)
+{
+    static size_t memoryHighWaterMark = 0;
+
+    if (ConsumeEventLoopTimerEvent(eventLoopTimer) != 0) {
+        dx_terminate(DX_ExitCode_ConsumeEventLoopMemoryMonitor);
+        return;
+    }
+
+#ifdef USE_AVNET_IOTCONNECT
+    if (dx_isAvnetConnected()) {
+#else
+    if (dx_isAzureConnected()) {
+#endif 
+        size_t newMemoryHighWaterMark = Applications_GetPeakUserModeMemoryUsageInKB();
+        if(newMemoryHighWaterMark > memoryHighWaterMark){
+           
+            memoryHighWaterMark = newMemoryHighWaterMark;
+            Log_Debug("New Memory High Water Mark: %d Kb\n", newMemoryHighWaterMark);
+            
+            // Serialize telemetry as JSON
+#ifdef USE_AVNET_IOTCONNECT            
+            bool serialization_result = dx_avnetJsonSerialize(msgBuffer, sizeof(msgBuffer), 1, 
+                                        DX_JSON_INT, "MemoryHighWaterMark", newMemoryHighWaterMark); 
+#else
+            bool serialization_result = dx_jsonSerialize(msgBuffer, sizeof(msgBuffer), 1, 
+                                        DX_JSON_INT, "MemoryHighWaterMark", newMemoryHighWaterMark); 
+#endif 
+            if (serialization_result) {
+                Log_Debug("%s\n", msgBuffer);
+                dx_azurePublish(msgBuffer, strlen(msgBuffer), memoryMessageProperties, NELEMS(memoryMessageProperties), &contentProperties);
+
+            } else {
+                Log_Debug("JSON Serialization failed: Buffer too small\n");
+            }
+        }
+    }
+}
+
+/// <summary>
+///  Initialize peripherals, device twins, direct methods, timer_bindings.
+/// </summary>
+static void InitPeripheralsAndHandlers(void)
+{
+#ifdef USE_AVNET_IOTCONNECT
+    dx_avnetConnect(&dx_config, NETWORK_INTERFACE);
+#else     
+    dx_azureConnect(&dx_config, NETWORK_INTERFACE, IOT_PLUG_AND_PLAY_MODEL_ID);
+#endif     
+    
+    dx_gpioSetOpen(gpio_bindings, NELEMS(gpio_bindings));
+    dx_timerSetStart(timer_bindings, NELEMS(timer_bindings));
+    dx_deviceTwinSubscribe(device_twin_bindings, NELEMS(device_twin_bindings));
+    dx_directMethodSubscribe(direct_method_bindings, NELEMS(direct_method_bindings));
+
+    // TODO: Update this call with a function pointer to a handler that will receive connection status updates
+    // see the azure_end_to_end example for an example
+    // dx_azureRegisterConnectionChangedNotification(NetworkConnectionState);
+}
+
+/// <summary>
+///     Close peripherals and handlers.
+/// </summary>
+static void ClosePeripheralsAndHandlers(void)
+{
+    dx_timerSetStop(timer_bindings, NELEMS(timer_bindings));
+    dx_deviceTwinUnsubscribe();
+    dx_directMethodUnsubscribe();
+    dx_gpioSetClose(gpio_bindings, NELEMS(gpio_bindings));
+    dx_timerEventLoopStop();
+}
+
+int main(int argc, char *argv[])
+{
+    dx_registerTerminationHandler();
+
+    if (!dx_configParseCmdLineArguments(argc, argv, &dx_config)) {
+        return dx_getTerminationExitCode();
+    }
+
+    InitPeripheralsAndHandlers();
+
+    // Main loop
+    while (!dx_isTerminationRequired()) {
+        int result = EventLoop_Run(dx_timerGetEventLoop(), -1, true);
+        // Continue if interrupted by signal, e.g. due to breakpoint being set.
+        if (result == -1 && errno != EINTR) {
+            dx_terminate(DX_ExitCode_Main_EventLoopFail);
+        }
+    }
+
+    ClosePeripheralsAndHandlers();
+    Log_Debug("Application exiting.\n");
+    return dx_getTerminationExitCode();
+}

--- a/examples/monitor_memory_usage/main.h
+++ b/examples/monitor_memory_usage/main.h
@@ -1,0 +1,78 @@
+#include "hw/azure_sphere_learning_path.h" // Hardware definition
+
+#include "app_exit_codes.h"
+#include "dx_azure_iot.h"
+#include "dx_config.h"
+#include "dx_json_serializer.h"
+#include "dx_terminate.h"
+#include "dx_timer.h"
+#include "dx_utilities.h"
+#include "dx_version.h"
+
+#include <applibs/log.h>
+#include <applibs/applications.h>
+
+// Use main.h to define all your application definitions, message properties/contentProperties,
+// bindings and binding sets.
+
+// https://docs.microsoft.com/en-us/azure/iot-pnp/overview-iot-plug-and-play
+#define IOT_PLUG_AND_PLAY_MODEL_ID "" //TODO insert your PnP model ID if your application supports PnP
+#define NETWORK_INTERFACE "wlan0"
+#define SAMPLE_VERSION_NUMBER "1.0"
+#define ONE_MS 1000000
+
+DX_USER_CONFIG dx_config;
+
+/****************************************************************************************
+ * Avnet IoTConnect Support
+ ****************************************************************************************/
+// TODO: If the application will connect to Avnet's IoTConnect platform enable the 
+// #define below
+// #define USE_AVNET_IOTCONNECT
+
+/****************************************************************************************
+ * Application defines
+ ****************************************************************************************/
+#define MIN_MEMORY_LEAK 1
+#define MAX_MEMORY_LEAK 50000
+#define MONITOR_PERIOD 30
+
+/****************************************************************************************
+ * Forward declarations
+ ****************************************************************************************/
+static DX_DIRECT_METHOD_RESPONSE_CODE MemoryLeakHandler(JSON_Value *json, DX_DIRECT_METHOD_BINDING *directMethodBinding, char **responseMsg);
+static void monitor_memory_handler(EventLoopTimer *eventLoopTimer);
+
+/****************************************************************************************
+ * Telemetry message buffer property sets
+ ****************************************************************************************/
+
+// Number of bytes to allocate for the JSON telemetry message for IoT Hub/Central
+#ifdef USE_AVNET_IOTCONNECT
+#define JSON_MESSAGE_BYTES 256+128 // Add additional buffer for the IoTConnect header data
+#else
+#define JSON_MESSAGE_BYTES 256
+#endif 
+static char msgBuffer[JSON_MESSAGE_BYTES] = {0};
+
+static DX_MESSAGE_PROPERTY *memoryMessageProperties[] = {&(DX_MESSAGE_PROPERTY){.key = "appid", .value = "hvac"}, 
+                                                        &(DX_MESSAGE_PROPERTY){.key = "type", .value = "memoryEvent"},
+                                                        &(DX_MESSAGE_PROPERTY){.key = "schema", .value = "1"}};
+
+static DX_MESSAGE_CONTENT_PROPERTIES contentProperties = {.contentEncoding = "utf-8", .contentType = "application/json"};
+
+/****************************************************************************************
+ * DevX Bindings
+ ****************************************************************************************/
+static DX_DIRECT_METHOD_BINDING dm_memory_leak = {.methodName = "MemoryLeak", .handler = MemoryLeakHandler};
+static DX_TIMER_BINDING tmr_monitor_memory = {.period = {MONITOR_PERIOD, 0}, .name = "tmr_monitor_memory", .handler = monitor_memory_handler};
+
+/****************************************************************************************
+ * Binding sets
+ ****************************************************************************************/
+// These sets are used by the initailization code.
+
+DX_DEVICE_TWIN_BINDING *device_twin_bindings[] = {};
+DX_DIRECT_METHOD_BINDING *direct_method_bindings[] = {&dm_memory_leak};
+DX_GPIO_BINDING *gpio_bindings[] = {};
+DX_TIMER_BINDING *timer_bindings[] = {&tmr_monitor_memory};

--- a/examples/starter_project/.clang-format
+++ b/examples/starter_project/.clang-format
@@ -1,0 +1,17 @@
+---
+BasedOnStyle: Google
+IndentWidth: 4
+---
+Language: Cpp
+AccessModifierOffset: -4
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+BreakBeforeBraces: WebKit
+ColumnLimit: 180
+DerivePointerAlignment: false
+KeepEmptyLinesAtTheStartOfBlocks: true
+PointerAlignment: Right
+SortIncludes: false
+SpacesBeforeTrailingComments: 1
+IndentCaseLabels: false

--- a/examples/starter_project/.gitignore
+++ b/examples/starter_project/.gitignore
@@ -1,0 +1,4 @@
+# Ignore output directories
+/out/
+/install/
+/.vs/

--- a/examples/starter_project/.vscode/launch.json
+++ b/examples/starter_project/.vscode/launch.json
@@ -1,0 +1,27 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch for Azure Sphere High-Level Applications (gdb)",
+            "type": "azurespheredbg",
+            "request": "launch",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": true,
+            "partnerComponents": [],
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ]
+        }
+    ]
+}

--- a/examples/starter_project/.vscode/settings.json
+++ b/examples/starter_project/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+    "cmake.generator": "Ninja",
+    "cmake.buildDirectory": "${workspaceRoot}/out/ARM-${buildType}",
+    "cmake.buildToolArgs": [ "-v" ],
+    "cmake.configureSettings": {
+        "CMAKE_TOOLCHAIN_FILE": "${command:azuresphere.AzureSphereSdkDir}/CMakeFiles/AzureSphereToolchain.cmake",
+        "AZURE_SPHERE_TARGET_API_SET": "10"
+    },
+    "cmake.configureOnOpen": true,
+    "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools",
+    "files.associations": {
+        "dx_avnet_iot_connect.h": "c",
+        "dx_json_serializer.h": "c"
+    }
+}

--- a/examples/starter_project/CMakeLists.txt
+++ b/examples/starter_project/CMakeLists.txt
@@ -1,0 +1,55 @@
+#  Copyright (c) Microsoft Corporation. All rights reserved.
+#  Licensed under the MIT License.
+
+###################################################################################################################
+
+# Select your developer board by removing the # tag from the beginning of the line
+
+# The default board selected is the AVNET Azure Sphere Starter Kit Revision 1.
+
+# If you are NOT using the AVNET Revision 1 board be sure to comment out the AVNET board
+
+set(AVNET TRUE "AVNET Azure Sphere Starter Kit Revision 1 ")    
+# set(AVNET_REV_2 TRUE "AVNET Azure Sphere Starter Kit Revision 2 ")             
+# set(SEEED_STUDIO_RDB TRUE "Seeed Studio Azure Sphere MT3620 Development Kit (aka Reference Design Board or rdb)")
+# set(SEEED_STUDIO_MINI TRUE "Seeed Studio Azure Sphere MT3620 Mini Dev Board")
+
+###################################################################################################################
+
+cmake_minimum_required (VERSION 3.10)
+
+project (azure_end_to_end C)
+
+azsphere_configure_tools(TOOLS_REVISION "21.07")
+azsphere_configure_api(TARGET_API_SET "10")
+
+add_subdirectory("../../" out)
+
+# Create executable
+add_executable (${PROJECT_NAME} main.c)
+target_link_libraries (${PROJECT_NAME} applibs pthread gcc_s c azure_sphere_devx)
+target_include_directories(${PROJECT_NAME} PUBLIC ../../include )
+
+
+if(AVNET)
+    add_definitions( -DOEM_AVNET=TRUE )
+    azsphere_target_hardware_definition(${PROJECT_NAME} TARGET_DIRECTORY "../HardwareDefinitions/avnet_mt3620_sk" TARGET_DEFINITION "azure_sphere_learning_path.json")
+endif(AVNET)
+
+if(AVNET_REV_2)
+    add_definitions( -DOEM_AVNET=TRUE )
+    azsphere_target_hardware_definition(${PROJECT_NAME} TARGET_DIRECTORY "../HardwareDefinitions/avnet_mt3620_sk_rev2" TARGET_DEFINITION "azure_sphere_learning_path.json")
+endif(AVNET_REV_2)
+
+if (SEEED_STUDIO_RDB)
+    add_definitions( -DOEM_SEEED_STUDIO=TRUE )
+    azsphere_target_hardware_definition(${PROJECT_NAME} TARGET_DIRECTORY "../HardwareDefinitions/mt3620_rdb" TARGET_DEFINITION "azure_sphere_learning_path.json")
+endif()
+
+if (SEEED_STUDIO_MINI)
+    add_definitions( -DOEM_SEEED_STUDIO_MINI=TRUE )
+    azsphere_target_hardware_definition(${PROJECT_NAME} TARGET_DIRECTORY "../HardwareDefinitions/seeed_mt3620_mdb" TARGET_DEFINITION "azure_sphere_learning_path.json")
+endif(SEEED_STUDIO_MINI)
+
+
+azsphere_target_add_image_package(${PROJECT_NAME})

--- a/examples/starter_project/CMakeSettings.json
+++ b/examples/starter_project/CMakeSettings.json
@@ -1,0 +1,47 @@
+﻿{
+  "environments": [
+    {
+      "environment": "AzureSphere"
+    }
+  ],
+  "configurations": [
+    {
+      "name": "ARM-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "inheritEnvironments": [
+        "AzureSphere"
+      ],
+      "buildRoot": "${projectDir}\\out\\${name}",
+      "installRoot": "${projectDir}\\out\\${name}",
+      "cmakeToolchain": "${env.AzureSphereDefaultSDKDir}CMakeFiles\\AzureSphereToolchain.cmake",
+      "buildCommandArgs": "-v",
+      "ctestCommandArgs": "",
+      "variables": [
+        {
+          "name": "AZURE_SPHERE_TARGET_API_SET",
+          "value": "10"
+        }
+      ]
+    },
+    {
+      "name": "ARM-Release",
+      "generator": "Ninja",
+      "configurationType": "Release",
+      "inheritEnvironments": [
+        "AzureSphere"
+      ],
+      "buildRoot": "${projectDir}\\out\\${name}",
+      "installRoot": "${projectDir}\\out\\${name}",
+      "cmakeToolchain": "${env.AzureSphereDefaultSDKDir}CMakeFiles\\AzureSphereToolchain.cmake",
+      "buildCommandArgs": "-v",
+      "ctestCommandArgs": "",
+      "variables": [
+        {
+          "name": "AZURE_SPHERE_TARGET_API_SET",
+          "value": "10"
+        }
+      ]
+    }
+  ]
+}

--- a/examples/starter_project/README.md
+++ b/examples/starter_project/README.md
@@ -1,0 +1,17 @@
+# Azure IoT Starter Project (empty)
+
+This is an empty (starter) project that can be used for new Azure Sphere applications based on the DevX library.  The project connects to an Azure IoTHub,
+IoTCentral, or Avnet's IoTConnect and nothing more.  Use the other examples in this folder to help you see how to build out the project to meet your requirements.  Search the project for "TODO" to see where to add definitions, declarations and code.
+## Config app_manifest.json sample
+
+1. Set ID Scope
+1. Set Allowed connections
+1. Set DeviceAuthentication
+
+For more information refer to:
+
+1. [Adding the Azure Sphere DevX library](https://github.com/gloveboxes/AzureSphereDevX/wiki/Adding-the-DevX-Library)
+1. [Azure Messaging](https://github.com/gloveboxes/AzureSphereDevX/wiki/IoT-Hub-Sending-messages)
+1. [Device Twins](https://github.com/gloveboxes/AzureSphereDevX/wiki/IoT-Hub-Device-Twins)
+1. [Direct Methods](https://github.com/gloveboxes/AzureSphereDevX/wiki/IoT-Hub-Direct-Methods)
+1. [GPIO](https://github.com/gloveboxes/AzureSphereDevX/wiki/Working-with-GPIO)

--- a/examples/starter_project/app_exit_codes.h
+++ b/examples/starter_project/app_exit_codes.h
@@ -1,0 +1,14 @@
+#pragma once
+
+/* Copyright (c) Microsoft Corporation. All rights reserved.
+   Licensed under the MIT License. */
+
+/// <summary>
+/// Exit codes for this application. Application exit codes
+/// must be between 1 and 149, where 0 is reserved for successful 
+//  termination.  dx_exit_codes.h owns/defines exit codes 0 and 
+/// 150 - 254.
+/// </summary>
+typedef enum {
+	APP_ExitCode_Telemetry_Buffer_Too_Small = 1
+} App_Exit_Code;

--- a/examples/starter_project/app_manifest.json
+++ b/examples/starter_project/app_manifest.json
@@ -1,0 +1,16 @@
+{
+  "SchemaVersion": 1,
+  "Name": "TODO_Add_app_name_here",
+  "ComponentId": "b217fd65-ac8d-4d7c-b62c-0d07b5df6357",
+  "EntryPoint": "/bin/app",
+  "CmdArgs": [ "--ScopeID", "TODO_REPLACE_WITH_YOUR_ID_SCOPE" ],
+  "Capabilities": {
+    "Gpio": [],
+    "AllowedConnections": [
+      "global.azure-devices-provisioning.net",
+      "TODO_REPLACE_WITH_YOUR_IOT_HUB_ENDPOINT_URL"
+    ],
+    "DeviceAuthentication": "TODO_REPLACE_WITH_YOUR_AZURE_SPHERE_TENANT_ID"
+  },
+  "ApplicationType": "Default"
+}

--- a/examples/starter_project/applibs_versions.h
+++ b/examples/starter_project/applibs_versions.h
@@ -1,0 +1,25 @@
+#pragma once
+
+/// <summary>
+/// This identifier should be defined before including any of the networking-related header files.
+/// It indicates which version of the Wi-Fi data structures the application uses.
+/// </summary>
+#define NETWORKING_STRUCTS_VERSION 1
+
+/// <summary>
+/// This identifier must be defined before including any of the Wi-Fi related header files.
+/// It indicates which version of the Wi-Fi data structures the application uses.
+/// </summary>
+#define WIFICONFIG_STRUCTS_VERSION 1
+
+/// <summary>
+/// This identifier must be defined before including any of the UART-related header files.
+/// It indicates which version of the UART data structures the application uses.
+/// </summary>
+#define UART_STRUCTS_VERSION 1
+
+/// <summary>
+/// This identifier must be defined before including any of the SPI-related header files.
+/// It indicates which version of the SPI data structures the application uses.
+/// </summary>
+#define SPI_STRUCTS_VERSION 1

--- a/examples/starter_project/launch.vs.json
+++ b/examples/starter_project/launch.vs.json
@@ -1,0 +1,21 @@
+﻿{
+  "version": "0.2.1",
+  "defaults": {},
+  "configurations": [
+    {
+      "type": "azurespheredbg",
+      "name": "GDB Debugger (HLCore)",
+      "project": "CMakeLists.txt",
+      "inheritEnvironments": [
+        "AzureSphere"
+      ],
+      "customLauncher": "AzureSphereLaunchOptions",
+      "workingDirectory": "${workspaceRoot}",
+      "applicationPath": "${debugInfo.target}",
+      "imagePath": "${debugInfo.targetImage}",
+      "targetCore": "HLCore",
+      "targetApiSet": "${env.AzureSphereTargetApiSet}",
+      "partnerComponents": [ "6583cf17-d321-4d72-8283-0b7c5b56442b" ]
+    }
+  ]
+}

--- a/examples/starter_project/main.c
+++ b/examples/starter_project/main.c
@@ -53,14 +53,6 @@
 #include <applibs/log.h>
 #include "main.h"
 
-// https://docs.microsoft.com/en-us/azure/iot-pnp/overview-iot-plug-and-play
-#define IOT_PLUG_AND_PLAY_MODEL_ID "" //TODO insert your PnP model ID if your application supports PnP
-#define NETWORK_INTERFACE "wlan0"
-#define SAMPLE_VERSION_NUMBER "1.0"
-#define ONE_MS 1000000
-
-DX_USER_CONFIG dx_config;
-
 /****************************************************************************************
  * Implementation
  ****************************************************************************************/

--- a/examples/starter_project/main.c
+++ b/examples/starter_project/main.c
@@ -1,0 +1,124 @@
+/* Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ *
+ * This example is built on the Azure Sphere DevX library.
+ *   1. DevX is an Open Source community-maintained implementation of the Azure Sphere SDK samples.
+ *   2. DevX is a modular library that simplifies common development scenarios.
+ *        - You can focus on your solution, not the plumbing.
+ *   3. DevX documentation is maintained at https://github.com/gloveboxes/AzureSphereDevX/wiki
+ *	 4. The DevX library is not a substitute for understanding the Azure Sphere SDK Samples.
+ *          - https://github.com/Azure/azure-sphere-samples
+ *
+ * DEVELOPER BOARD SELECTION
+ *
+ * The following developer boards are supported.
+ *
+ *	 1. AVNET Azure Sphere Starter Kit.
+ *   2. AVNET Azure Sphere Starter Kit Revision 2.
+ *	 3. Seeed Studio Azure Sphere MT3620 Development Kit aka Reference Design Board or rdb.
+ *	 4. Seeed Studio Seeed Studio MT3620 Mini Dev Board.
+ *
+ * ENABLE YOUR DEVELOPER BOARD
+ *
+ * Each Azure Sphere developer board manufacturer maps pins differently. You need to select the
+ *    configuration that matches your board.
+ *
+ * Follow these steps:
+ *
+ *	 1. Open CMakeLists.txt.
+ *	 2. Uncomment the set command that matches your developer board.
+ *	 3. Click File, then Save to auto-generate the CMake Cache.
+ *
+ *  How to use this sample
+ * 
+ *    Developers can use this sample as a starting point for their DevX based Azure Sphere 
+ *    application.  It will connect to an Azure IoTHub, IOTCentral or Avnet's IoTConnect.  
+ * 
+ *    There are sections marked with "TODO" that the developer can review for hints on where
+ *    to add code, or to enable code that may be needed for general support, such as sending
+ *    telemetry.
+ * 
+ ************************************************************************************************/
+
+#include "hw/azure_sphere_learning_path.h" // Hardware definition
+
+#include "app_exit_codes.h"
+#include "dx_azure_iot.h"
+#include "dx_config.h"
+#include "dx_json_serializer.h"
+#include "dx_terminate.h"
+#include "dx_timer.h"
+#include "dx_utilities.h"
+#include "dx_version.h"
+#include <applibs/log.h>
+#include "main.h"
+
+// https://docs.microsoft.com/en-us/azure/iot-pnp/overview-iot-plug-and-play
+#define IOT_PLUG_AND_PLAY_MODEL_ID "" //TODO insert your PnP model ID if your application supports PnP
+#define NETWORK_INTERFACE "wlan0"
+#define SAMPLE_VERSION_NUMBER "1.0"
+#define ONE_MS 1000000
+
+DX_USER_CONFIG dx_config;
+
+/****************************************************************************************
+ * Implementation
+ ****************************************************************************************/
+// TODO: Add all your handlers and helper functions here
+
+/// <summary>
+///  Initialize peripherals, device twins, direct methods, timer_bindings.
+/// </summary>
+static void InitPeripheralsAndHandlers(void)
+{
+#ifdef USE_AVNET_IOTCONNECT
+    dx_avnetConnect(&dx_config, NETWORK_INTERFACE);
+#else     
+    dx_azureConnect(&dx_config, NETWORK_INTERFACE, IOT_PLUG_AND_PLAY_MODEL_ID);
+#endif     
+    
+    dx_gpioSetOpen(gpio_bindings, NELEMS(gpio_bindings));
+    dx_timerSetStart(timer_bindings, NELEMS(timer_bindings));
+    dx_deviceTwinSubscribe(device_twin_bindings, NELEMS(device_twin_bindings));
+    dx_directMethodSubscribe(direct_method_bindings, NELEMS(direct_method_bindings));
+
+    // TODO: Update this call with a function pointer to a handler that will receive connection status updates
+    // see the azure_end_to_end example for an example
+    // dx_azureRegisterConnectionChangedNotification(NetworkConnectionState);
+}
+
+/// <summary>
+///     Close peripherals and handlers.
+/// </summary>
+static void ClosePeripheralsAndHandlers(void)
+{
+    dx_timerSetStop(timer_bindings, NELEMS(timer_bindings));
+    dx_deviceTwinUnsubscribe();
+    dx_directMethodUnsubscribe();
+    dx_gpioSetClose(gpio_bindings, NELEMS(gpio_bindings));
+    dx_timerEventLoopStop();
+}
+
+int main(int argc, char *argv[])
+{
+    dx_registerTerminationHandler();
+
+    if (!dx_configParseCmdLineArguments(argc, argv, &dx_config)) {
+        return dx_getTerminationExitCode();
+    }
+
+    InitPeripheralsAndHandlers();
+
+    // Main loop
+    while (!dx_isTerminationRequired()) {
+        int result = EventLoop_Run(dx_timerGetEventLoop(), -1, true);
+        // Continue if interrupted by signal, e.g. due to breakpoint being set.
+        if (result == -1 && errno != EINTR) {
+            dx_terminate(DX_ExitCode_Main_EventLoopFail);
+        }
+    }
+
+    ClosePeripheralsAndHandlers();
+    Log_Debug("Application exiting.\n");
+    return dx_getTerminationExitCode();
+}

--- a/examples/starter_project/main.h
+++ b/examples/starter_project/main.h
@@ -1,0 +1,51 @@
+// Use main.h to define all your application definitions, message properties/contentProperties,
+// bindings and binding sets.
+
+/****************************************************************************************
+ * Avnet IoTConnect Support
+ ****************************************************************************************/
+// TODO: If the application will connect to Avnet's IoTConnect platform enable the 
+// #define below
+#define USE_AVNET_IOTCONNECT
+
+/****************************************************************************************
+ * Forward declarations
+ ****************************************************************************************/
+// TODO: Add all Forward declarations here or in main.c
+
+/****************************************************************************************
+ * Telemetry message buffer property sets
+ ****************************************************************************************/
+
+// Number of bytes to allocate for the JSON telemetry message for IoT Hub/Central
+// TODO: Remove comments to use the global message buffer for sending telemetry
+//#define JSON_MESSAGE_BYTES 256
+//static char msgBuffer[JSON_MESSAGE_BYTES] = {0};
+
+// TODO: Define telemetry message properties here, for example . . . 
+//static DX_MESSAGE_PROPERTY *messageProperties[] = {&(DX_MESSAGE_PROPERTY){.key = "appid", .value = "hvac"}, 
+//                                                   &(DX_MESSAGE_PROPERTY){.key = "type", .value = "telemetry"},
+//                                                   &(DX_MESSAGE_PROPERTY){.key = "schema", .value = "1"}};
+
+// TODO: Remove comments to define contentProperties for sending telemetry
+//static DX_MESSAGE_CONTENT_PROPERTIES contentProperties = {.contentEncoding = "utf-8", .contentType = "application/json"};
+
+/****************************************************************************************
+ * Bindings
+ ****************************************************************************************/
+// TODO: Declare all bindings here, for example . . . 
+
+//static DX_DEVICE_TWIN_BINDING dt_desired_sample_rate = {.propertyName = "DesiredSampleRate", .twinType = DX_DEVICE_TWIN_INT, .handler = dt_desired_sample_rate_handler};
+//static DX_GPIO_BINDING gpio_led = {.pin = LED2, .name = "gpio_led", .direction = DX_OUTPUT, .initialState = GPIO_Value_Low, .invertPin = true};
+//static DX_TIMER_BINDING tmr_publish_message = {.period = {4, 0}, .name = "tmr_publish_message", .handler = publish_message_handler};
+
+/****************************************************************************************
+ * Binding sets
+ ****************************************************************************************/
+// TODO: Update each binding set below with the bindings defined above.  Add bindings by reference, i.e., &dt_desired_sample_rate
+// These sets are used by the initailization code.
+
+DX_DEVICE_TWIN_BINDING *device_twin_bindings[] = {};
+DX_DIRECT_METHOD_BINDING *direct_method_bindings[] = {};
+DX_GPIO_BINDING *gpio_bindings[] = {};
+DX_TIMER_BINDING *timer_bindings[] = {};

--- a/examples/starter_project/main.h
+++ b/examples/starter_project/main.h
@@ -1,12 +1,29 @@
 // Use main.h to define all your application definitions, message properties/contentProperties,
 // bindings and binding sets.
 
+// https://docs.microsoft.com/en-us/azure/iot-pnp/overview-iot-plug-and-play
+#define IOT_PLUG_AND_PLAY_MODEL_ID "" //TODO insert your PnP model ID if your application supports PnP
+
+// Details on how to connect your application using an ethernet adaptor
+// https://docs.microsoft.com/en-us/azure-sphere/network/connect-ethernet
+#define NETWORK_INTERFACE "wlan0"
+
+#define SAMPLE_VERSION_NUMBER "1.0"
+#define ONE_MS 1000000
+
+DX_USER_CONFIG dx_config;
+
 /****************************************************************************************
  * Avnet IoTConnect Support
  ****************************************************************************************/
 // TODO: If the application will connect to Avnet's IoTConnect platform enable the 
 // #define below
-#define USE_AVNET_IOTCONNECT
+//#define USE_AVNET_IOTCONNECT
+
+/****************************************************************************************
+ * Application defines
+ ****************************************************************************************/
+// TODO: Add any application constants
 
 /****************************************************************************************
  * Forward declarations


### PR DESCRIPTION
Added a new example starter_project that is basically an empty DevX application.  The code has "TODO" comments to guide the developer to where to add custom implementation code.

Add a new example monitor_memory_usage that implement a timer to monitor application memory usage.  Each time a higher memory usage value is detected the handler sends up telemetry with the new value.  There is also a direct method to leak memory so that the feature can be tested.