### PR TITLE
Add telemetry delivered notification logic and the ability to remove a device twin from the cloud 

### DIFF
--- a/include/dx_azure_iot.h
+++ b/include/dx_azure_iot.h
@@ -125,5 +125,12 @@ void dx_azureRegisterDeviceTwinCallback(void (*deviceTwinCallbackHandler)(DEVICE
 void dx_azureRegisterDirectMethodCallback(int (*directMethodCallbackHandler)(const char *method_name, const unsigned char *payload,
                                                                              size_t payloadSize, unsigned char **responsePayload,
                                                                              size_t *responsePayloadSize, void *userContextCallback));
+/// <summary>
+/// Returns the outstanding Telemetry message count.  This variable is incrremented 
+/// each time the application sends a telemetry message and decremented each time a 
+/// telemetry message has been accepted by the IoTHub.
+/// </summary>
+int dx_azureGetOutstandingMessageCount(void);
+
 
 

--- a/src/dx_azure_iot.c
+++ b/src/dx_azure_iot.c
@@ -387,6 +387,16 @@ IOTHUB_DEVICE_CLIENT_LL_HANDLE dx_azureClientHandleGet(void)
     return iothubClientHandle;
 }
 
+/// <summary>
+/// Returns the outstanding Telemetry message count.  This variable is incrremented 
+/// each time the application sends a telemetry message and decremented each time a 
+/// telemetry message has been accepted by the IoTHub.
+/// </summary>
+int dx_azureGetOutstandingMessageCount(void)
+{
+    return outstandingMessageCount;
+}
+
 static IOTHUBMESSAGE_DISPOSITION_RESULT HubMessageReceivedCallback(IOTHUB_MESSAGE_HANDLE message, void *context)
 {
     if (_messageReceivedCallback != NULL) {


### PR DESCRIPTION
Add a helper function `int dx_azureGetOutstandingMessageCount(void);` to return the number of outstanding telemetry messages that have been sent to the IoTHub but not ACKed by the IoTHub.  Can be used to verify that a telemetry message was received at the Hub.

Add functionality to remove a device twin from the cloud copy device twin json document.  When users pass in a NULL parameter for the status the device twin is removed from the cloud copy.

You can call either of the device twin report properties functions and pass in NULL for the state pointer and the reported property referenced by the deviceTwinBinding is removed.

dx_deviceTwinAckDesiredValue(deviceTwinBinding, NULL, DX_DEVICE_TWIN_RESPONSE_COMPLETED);

OR

dx_deviceTwinReportValue(deviceTwinBinding, NULL);

